### PR TITLE
Use PHP sha1() function instead of MySQL SHA1()

### DIFF
--- a/src/bb-modules/Staff/Service.php
+++ b/src/bb-modules/Staff/Service.php
@@ -43,7 +43,7 @@ class Service implements InjectionAwareInterface
 
         $this->di['events_manager']->fire(array('event'=>'onBeforeAdminLogin', 'params'=>$event_params));
 
-        $model = $this->di['db']->findOne('Admin', "email = ? AND pass = SHA1(?) AND status = ?", array( $email, $password, 'active' ));
+        $model = $this->di['db']->findOne('Admin', "email = ? AND pass = ? AND status = ?", array( $email, sha1($password), 'active' ));
         if(!$model instanceof \Model_Admin ) {
             $this->di['events_manager']->fire(array('event'=>'onEventAdminLoginFailed', 'params'=>$event_params));
             throw new \Box_Exception('Check your login details', null, 403);

--- a/src/install/index.php
+++ b/src/install/index.php
@@ -289,8 +289,8 @@ final class Box_Installer
             throw new Exception($err);
         }
 
-        $sql = "INSERT INTO admin (role, name, email, pass, protected, created_at, updated_at) VALUES('admin', '%s', '%s', SHA1('%s'), 1, '%s', '%s');";
-        $sql = sprintf($sql, mysql_real_escape_string($ns->get('admin_name')), mysql_real_escape_string($ns->get('admin_email')), mysql_real_escape_string($ns->get('admin_pass')), date('c'), date('c'));
+        $sql = "INSERT INTO admin (role, name, email, pass, protected, created_at, updated_at) VALUES('admin', '%s', '%s', '%s', 1, '%s', '%s');";
+        $sql = sprintf($sql, mysql_real_escape_string($ns->get('admin_name')), mysql_real_escape_string($ns->get('admin_email')), mysql_real_escape_string(sha1($ns->get('admin_pass'))), date('c'), date('c'));
         $res = mysql_query($sql, $link);
         if(!$res) {
             throw new Exception(mysql_error());


### PR DESCRIPTION
[From the MySQL documentation](http://dev.mysql.com/doc/refman/5.5/en/encryption-functions.html):

> **Caution**
> Passwords or other sensitive values supplied as arguments to encryption functions are sent in plaintext to the MySQL server unless an SSL connection is used. Also, such values will appear in any MySQL logs to which they are written. To avoid these types of exposure, applications can encrypt sensitive values on the client side before sending them to the server.

PHP does not use SSL by default to connect to MySQL, so I think this is important.

I know the use of `mysql_real_escape_string()` in the _install/index.php_ can be removed, but it does no harm to have it.

By the way, thanks for uploading the source to GitHub. I am delighted that you finally have been able to release it. For me, it's the news of the month :smiley:
