### PR TITLE
fix admin API currency_get() method return

### DIFF
--- a/src/bb-modules/Currency/Api/Admin.php
+++ b/src/bb-modules/Currency/Api/Admin.php
@@ -60,9 +60,12 @@ class Admin extends \Api_Abstract
         }
 
         $service = $this->getService();
-        $curency = $service->getByCode($data['code']);
+        $model = $service->getByCode($data['code']);
 
-        return $curency;
+        if(!$model instanceof \Model_Currency) {
+            throw new \Box_Exception('Currency not found');
+        }
+        return $service->toApiArray($model);
     }
 
     /**

--- a/tests/bb-modules/Currency/Api/Api_AdminTest.php
+++ b/tests/bb-modules/Currency/Api/Api_AdminTest.php
@@ -220,7 +220,7 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $service->expects($this->atLeastOnce())
             ->method('getByCode')
             ->will($this->returnValue($model));
-        $serviceMock->expects($this->atLeastOnce())
+        $service->expects($this->atLeastOnce())
             ->method('toApiArray')
             ->will($this->returnValue(array()));
 

--- a/tests/bb-modules/Currency/Api/Api_AdminTest.php
+++ b/tests/bb-modules/Currency/Api/Api_AdminTest.php
@@ -220,14 +220,16 @@ class AdminTest extends \PHPUnit_Framework_TestCase
         $service->expects($this->atLeastOnce())
             ->method('getByCode')
             ->will($this->returnValue($model));
+        $serviceMock->expects($this->atLeastOnce())
+            ->method('toApiArray')
+            ->will($this->returnValue(array()));
 
         $data = array(
             'code' => 'EUR'
         );
         $adminApi->setService($service);
         $result = $adminApi->get($data);
-        $this->assertInternalType('object', $result);
-        $this->assertInstanceOf('Model_Currency', $result);
+        $this->assertInternalType('array', $result);
     }
 
     public function testGetExceptionProvider()

--- a/tests/integration/bb-modules/mod_currency/Api_AdminTest.php
+++ b/tests/integration/bb-modules/mod_currency/Api_AdminTest.php
@@ -11,9 +11,9 @@ class Api_Admin_CurrencyTest extends BBDbApiTestCase
         $array = $this->api_admin->currency_get_pairs();
         $this->assertInternalType('array', $array);
 
-        $currency = $this->api_admin->currency_get(array('code' => 'USD'));
-        $this->assertInstanceOf('Model_Currency', $currency);
-        $this->assertEquals($currency->code, 'USD');
+        $array = $this->api_admin->currency_get(array('code' => 'USD'));
+        $this->assertInternalType('array', $array);
+        $this->assertEquals('USD', $array['code']);
 
         $array = $this->api_admin->currency_get_default();
         $this->assertInternalType('array', $array);


### PR DESCRIPTION
Admin API ```currency_get()``` method call returns ```Model_Currency``` instance, but should return an array.