### PR TITLE
Nginx template: Disable PHP inside bb-uploads and bb-data

### DIFF
--- a/data/nginx.conf
+++ b/data/nginx.conf
@@ -26,6 +26,12 @@
          include fastcgi_params;
      }
 
+     # Disable PHP execution in bb-uploads and bb-data
+     location ^~ /bb-uploads/ { }
+     location ^~ /bb-data/ {
+       deny all;
+     }
+
      location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
          root $root_path;
          expires off;


### PR DESCRIPTION
The nginx `^~` prefix skips the PHP regex location.

From http://nginx.org/en/docs/http/ngx_http_core_module.html#location:
> If the longest matching prefix location has the “^~” modifier then regular expressions are not checked.

Related comment in [4.14 Changelog updated (65c52fc)](https://github.com/boxbilling/boxbilling/commit/65c52fcfbae005fc7d53da80c03396b536f929d8#commitcomment-9712706).