### PR TITLE
robots.txt: Allow Googlebot access to JavaScript, CSS and images

### DIFF
--- a/src/robots.txt
+++ b/src/robots.txt
@@ -16,7 +16,5 @@ Disallow: /bb-data/
 Disallow: /bb-library/
 Disallow: /bb-locale/
 Disallow: /bb-modules/
-Disallow: /bb-themes/
-Disallow: /bb-uploads/
 Disallow: /bb-vendor/
 Disallow: /install/


### PR DESCRIPTION
https://developers.google.com/webmasters/mobile-sites/mobile-seo/common-mistakes/blocked-resources:

> For optimal rendering and indexing, always allow Googlebot access to the JavaScript, CSS, and image files used by your website so that Googlebot can see your site like an average user. If your site’s robots.txt file disallows crawling of these assets, it directly harms how well our algorithms render and index your content. This can result in suboptimal rankings.