### PR TITLE
Forcing API Key Auth for ResellerClub and derived registrars

### DIFF
--- a/src/bb-library/Registrar/Adapter/Netearthone.php
+++ b/src/bb-library/Registrar/Adapter/Netearthone.php
@@ -12,33 +12,33 @@ class Registrar_Adapter_Netearthone extends Registrar_Adapter_Resellerclub
             $this->config['userid'] = $options['userid'];
             unset($options['userid']);
         } else {
-            throw new Registrar_Exception('Domain registrar "NetEarthOne" is not configured properly. Please update configuration parameter "NetEarthOne Username" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('Domain registrar "NetEarthOne" is not configured properly. Please update configuration parameter "NetEarthOne Reseller ID" at "Configuration -> Domain registration".');
         }
 
-        if(isset($options['password']) && !empty($options['password'])) {
-            $this->config['password'] = $options['password'];
-            unset($options['password']);
+        if(isset($options['api-key']) && !empty($options['api-key'])) {
+            $this->config['api-key'] = $options['api-key'];
+            unset($options['api-key']);
         } else {
-            throw new Registrar_Exception('Domain registrar "NetEarthOne" is not configured properly. Please update configuration parameter "NetEarthOne Pasword" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('Domain registrar "NetEarthOne" is not configured properly. Please update configuration parameter "NetEarthOne API Key" at "Configuration -> Domain registration".');
         }
     }
-    
+
     public static function getConfig()
     {
         return array(
-            'label'     =>  'Manages domains on NetEarthOne via API',
+            'label'     =>  'Manages domains on NetEarthOne via API. NetEarthOne requires your server IP in order to work. Login to the NetEarthOne control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where BoxBilling is installed to authorize it for API access.',
             'form'  => array(
                 'userid' => array('text', array(
-                            'label' => 'NetEarthOne Username', 
-                            'description'=>'NetEarthOne Username'
-                        ),
-                     ),
-                'password' => array('password', array(
-                            'label' => 'NetEarthOne Pasword', 
-                            'description'=>'NetEarthOne Password',
-                            'renderPassword'    =>  true, 
-                        ),
-                     ),
+                    'label' => 'Reseller ID. You can get this at NetEarthOne control panel Settings > Personal information > Primary profile > Reseller ID',
+                    'description'=> 'NetEarthOne Reseller ID'
+                ),
+                ),
+                'api-key' => array('password', array(
+                    'label' => 'NetEarthOne API Key',
+                    'description'=> 'You can get this at NetEarthOne control panel, go to Settings -> API',
+                    'required' => false,
+                ),
+                ),
             ),
         );
     }

--- a/src/bb-library/Registrar/Adapter/Resellbiz.php
+++ b/src/bb-library/Registrar/Adapter/Resellbiz.php
@@ -12,30 +12,33 @@ class Registrar_Adapter_Resellbiz extends Registrar_Adapter_Resellerclub
             $this->config['userid'] = $options['userid'];
             unset($options['userid']);
         } else {
-            throw new Registrar_Exception('Domain registrar "ResellBiz" is not configured properly. Please update configuration parameter "ResellBiz Username" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('Domain registrar "Resell.biz" is not configured properly. Please update configuration parameter "Resell.biz Reseller ID" at "Configuration -> Domain registration".');
         }
 
-        if(isset($options['password']) && !empty($options['password'])) {
-            $this->config['password'] = $options['password'];
-            unset($options['password']);
+        if(isset($options['api-key']) && !empty($options['api-key'])) {
+            $this->config['api-key'] = $options['api-key'];
+            unset($options['api-key']);
         } else {
-            throw new Registrar_Exception('Domain registrar "ResellBiz" is not configured properly. Please update configuration parameter "ResellBiz Pasword" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('Domain registrar "Resell.biz" is not configured properly. Please update configuration parameter "Resell.biz API Key" at "Configuration -> Domain registration".');
         }
     }
-    
+
     public static function getConfig()
     {
         return array(
-            'label'     =>  'Manages domains on ResellBiz via API',
+            'label'     =>  'Manages domains on Resell.biz via API. Resell.biz requires your server IP in order to work. Login to the Resell.biz control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where BoxBilling is installed to authorize it for API access.',
             'form'  => array(
                 'userid' => array('text', array(
-                            'label' => 'Reseller ID',
-                        ),
-                     ),
-                'password' => array('password', array(
-                            'label' => 'Password',
-                        ),
-                     ),
+                    'label' => 'Reseller ID. You can get this at Resell.biz control panel Settings > Personal information > Primary profile > Reseller ID',
+                    'description'=> 'Resell.biz Reseller ID'
+                ),
+                ),
+                'api-key' => array('password', array(
+                    'label' => 'Resell.biz API Key',
+                    'description'=> 'You can get this at Resell.biz control panel, go to Settings -> API',
+                    'required' => false,
+                ),
+                ),
             ),
         );
     }

--- a/src/bb-library/Registrar/Adapter/Resellerclub.php
+++ b/src/bb-library/Registrar/Adapter/Resellerclub.php
@@ -43,47 +43,34 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
             throw new Registrar_Exception('CURL extension is not enabled');
         }
 
-        if(!$this->isKeyValueNotEmpty($options, 'userid')) {
-            throw new Registrar_Exception('Domain registrar "Resellerclub" is not configured properly. Please update configuration parameter "Resellerclub Username" at "Configuration -> Domain registration".');
+        if(isset($options['userid']) && !empty($options['userid'])) {
+            $this->config['userid'] = $options['userid'];
+            unset($options['userid']);
+        } else {
+            throw new Registrar_Exception('Domain registrar "ResellerClub" is not configured properly. Please update configuration parameter "ResellerClub Reseller ID" at "Configuration -> Domain registration".');
         }
 
-        $this->config['userid'] = $options['userid'];
-        unset($options['userid']);
-
-        if($this->isKeyValueNotEmpty($options, 'password')){
-            $this->config['password'] = $options['password'];
-            unset($options['password']);
-        }
-
-        if($this->isKeyValueNotEmpty($options, 'api-key')) {
+        if(isset($options['api-key']) && !empty($options['api-key'])) {
             $this->config['api-key'] = $options['api-key'];
             unset($options['api-key']);
-        }
-
-        if (!isset($this->config['api-key']) && !isset($this->config['password'])){
-            throw new Registrar_Exception('Domain registrar "Resellerclub" is not configured properly. Please update configuration parameter "Resellerclub Password or API key" at "Configuration -> Domain registration".');
+        } else {
+            throw new Registrar_Exception('Domain registrar "ResellerClub" is not configured properly. Please update configuration parameter "ResellerClub API Key" at "Configuration -> Domain registration".');
         }
     }
     
     public static function getConfig()
     {
         return array(
-            'label'     =>  'Manages domains on Resellerclub via API. ResellerClub requires your server IP in order to work. Login to the ResellerClub control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where BoxBilling is installed to authorize it for API access.',
+            'label'     =>  'Manages domains on ResellerClub via API. ResellerClub requires your server IP in order to work. Login to the ResellerClub control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where BoxBilling is installed to authorize it for API access.',
             'form'  => array(
                 'userid' => array('text', array(
-                            'label' => 'Reseller ID. You can get this at ResellerClub control panel Settings > Personal information > Primary profile > Reseller ID', 
-                            'description'=>'Resellerclub Username'
-                        ),
-                     ),
-                'password' => array('password', array(
-                            'label' => 'Resellerclub Pasword', 
-                            'description'=>'Resellerclub Password',
-                            'required' => false,
+                            'label' => 'Reseller ID. You can get this at ResellerClub control panel Settings > Personal information > Primary profile > Reseller ID',
+                            'description'=> 'ResellerClub Reseller ID'
                         ),
                      ),
                 'api-key' => array('password', array(
-                            'label' => 'Resellerclub API Key',
-                            'description'=> 'You can get this at ResellerClub control panel, go to Settings -> API. (Preferred)',
+                            'label' => 'ResellerClub API Key',
+                            'description'=> 'You can get this at ResellerClub control panel, go to Settings -> API',
                             'required' => false,
                         ),
                      ),
@@ -676,17 +663,10 @@ class Registrar_Adapter_Resellerclub extends Registrar_AdapterAbstract
      */
     public function includeAuthorizationParams(array $params)
     {
-        $params['auth-userid'] = $this->config['userid'];
-
-        if (isset($this->config['api-key'])){
-            $params['api-key'] = $this->config['api-key'];
-        }
-
-        if (!isset($params['api-key'])){
-            $params['auth-password'] = $this->config['password'];
-        }
-
-        return $params;
+        return array_merge($params, array(
+            'auth-userid' => $this->config['userid'],
+            'api-key' => $this->config['api-key'],
+        ));
     }
 
     /**

--- a/src/bb-library/Registrar/Adapter/Resellerid.php
+++ b/src/bb-library/Registrar/Adapter/Resellerid.php
@@ -12,30 +12,33 @@ class Registrar_Adapter_Resellerid extends Registrar_Adapter_Resellerclub
             $this->config['userid'] = $options['userid'];
             unset($options['userid']);
         } else {
-            throw new Registrar_Exception('Domain registrar "ResellerID" is not configured properly. Please update configuration parameter "ResellerID Username" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('Domain registrar "ResellerID" is not configured properly. Please update configuration parameter "ResellerID Reseller ID" at "Configuration -> Domain registration".');
         }
 
-        if(isset($options['password']) && !empty($options['password'])) {
-            $this->config['password'] = $options['password'];
-            unset($options['password']);
+        if(isset($options['api-key']) && !empty($options['api-key'])) {
+            $this->config['api-key'] = $options['api-key'];
+            unset($options['api-key']);
         } else {
-            throw new Registrar_Exception('Domain registrar "ResellerID" is not configured properly. Please update configuration parameter "ResellerID Pasword" at "Configuration -> Domain registration".');
+            throw new Registrar_Exception('Domain registrar "ResellerID" is not configured properly. Please update configuration parameter "ResellerID API Key" at "Configuration -> Domain registration".');
         }
     }
-    
+
     public static function getConfig()
     {
         return array(
-            'label'     =>  'Manages domains on ResellerID via API',
+            'label'     =>  'Manages domains on ResellerID via API. ResellerID requires your server IP in order to work. Login to the ResellerID control panel (the url will be in the email you received when you signed up with them) and then go to Settings > API and enter the IP address of the server where BoxBilling is installed to authorize it for API access.',
             'form'  => array(
                 'userid' => array('text', array(
-                            'label' => 'Reseller ID',
-                        ),
-                     ),
-                'password' => array('password', array(
-                            'label' => 'Reseller Pasword',
-                        ),
-                     ),
+                    'label' => 'Reseller ID. You can get this at ResellerID control panel Settings > Personal information > Primary profile > Reseller ID',
+                    'description'=> 'ResellerID Reseller ID'
+                ),
+                ),
+                'api-key' => array('password', array(
+                    'label' => 'ResellerID API Key',
+                    'description'=> 'You can get this at ResellerID control panel, go to Settings -> API',
+                    'required' => false,
+                ),
+                ),
             ),
         );
     }


### PR DESCRIPTION
Starting April 28, password authentication is no longer possible on LogicBoxes based registrars. This modification removes the password field from ResellerClub and derived registrars and adds the API Key field to derived registrars, effectively forcing API Key usage in the billing system itself.