### PR TITLE
Fix PayPal IPN verification

### DIFF
--- a/src/bb-library/Payment/Adapter/PayPalEmail.php
+++ b/src/bb-library/Payment/Adapter/PayPalEmail.php
@@ -241,6 +241,8 @@ class Payment_Adapter_PayPalEmail implements \Box\InjectionAwareInterface
 		$headers = Array(
 			($post_contents ? 'POST' : 'GET')." $path HTTP/1.1",
 			"Host: $host",
+            'Connection: Close',
+            'User-Agent: BoxBilling'
 		);
 		if (!empty($phd)) {
 			if (!is_array($phd)) {


### PR DESCRIPTION
The request to check if the PayPal IPN is valid fails returning a **403 Forbidden** error.

```HTTP
> POST /cgi-bin/webscr HTTP/1.1
Accept: */*
Host: www.paypal.com
Content-Type: application/x-www-form-urlencoded
Content-Length: 819

* upload completely sent off: 819 out of 819 bytes
* additional stuff not fine transfer.c:1037: 0 0
* HTTP 1.1 or later with persistent connection, pipelining supported
< HTTP/1.1 403 Forbidden
< Server: BigIP
< Content-Length: 0
< Date: Tue, 26 May 2015 19:29:51 GMT
< Connection: close
< Strict-Transport-Security: max-age=63072000
< 
* Closing connection #0
```

This is due to some change in the PayPal platform that now requires that the `User-Agent` header is present in the request. More info in this Stack Overflow thread:

https://stackoverflow.com/questions/25854207/access-denied-on-paypal-ipn-verification