### PR TITLE
Filter phone_cc before create/update

### DIFF
--- a/src/bb-modules/Client/Api/Admin.php
+++ b/src/bb-modules/Client/Api/Admin.php
@@ -248,6 +248,11 @@ class Admin extends \Api_Abstract
 
         $this->di['events_manager']->fire(array('event'=>'onBeforeAdminClientUpdate', 'params'=>$data));
 
+        $phoneCC = $this->di['array_get']($data, 'phone_cc', $client->phone_cc);
+        if(!empty($phoneCC)){
+            $client->phone_cc = intval($phoneCC);
+        }
+
         $client->email          = $this->di['array_get']($data, 'email', $client->email);
         $client->first_name     = $this->di['array_get']($data, 'first_name', $client->first_name);
         $client->last_name      = $this->di['array_get']($data, 'last_name', $client->last_name);
@@ -258,7 +263,6 @@ class Admin extends \Api_Abstract
         $client->company_vat    = $this->di['array_get']($data, 'company_vat', $client->company_vat);
         $client->address_1      = $this->di['array_get']($data, 'address_1', $client->address_1);
         $client->address_2      = $this->di['array_get']($data, 'address_2', $client->address_2);
-        $client->phone_cc       = $this->di['array_get']($data, 'phone_cc', $client->phone_cc);
         $client->phone          = $this->di['array_get']($data, 'phone', $client->phone);
         $client->document_type  = $this->di['array_get']($data, 'document_type', $client->document_type);
         $client->document_nr    = $this->di['array_get']($data, 'document_nr', $client->document_nr);

--- a/src/bb-modules/Client/Api/Client.php
+++ b/src/bb-modules/Client/Api/Client.php
@@ -85,6 +85,11 @@ class Client extends \Api_Abstract
             $client->email = strtolower(trim($email));
         }
 
+        $phoneCC = $this->di['array_get']($data, 'phone_cc', $client->phone_cc);
+        if(!empty($phoneCC)){
+            $client->phone_cc = intval($phoneCC);
+        }
+
         $client->first_name     = $this->di['array_get']($data, 'first_name', $client->first_name);
         $client->last_name      = $this->di['array_get']($data, 'last_name', $client->last_name);
         $client->gender         = $this->di['array_get']($data, 'gender', $client->gender);
@@ -95,7 +100,6 @@ class Client extends \Api_Abstract
         $client->type           = $this->di['array_get']($data, 'type', $client->type);
         $client->address_1      = $this->di['array_get']($data, 'address_1', $client->address_1);
         $client->address_2      = $this->di['array_get']($data, 'address_2', $client->address_2);
-        $client->phone_cc       = $this->di['array_get']($data, 'phone_cc', $client->phone_cc);
         $client->phone          = $this->di['array_get']($data, 'phone', $client->phone);
         $client->country        = $this->di['array_get']($data, 'country', $client->country);
         $client->postcode       = $this->di['array_get']($data, 'postcode', $client->postcode);
@@ -120,7 +124,7 @@ class Client extends \Api_Abstract
         $this->di['db']->store($client);
 
         $this->di['events_manager']->fire(array('event'=>'onAfterClientProfileUpdate', 'params'=>array('id'=>$client->id)));
-        
+
         $this->di['logger']->info('Updated profile');
         return true;
     }

--- a/src/bb-modules/Client/Api/Guest.php
+++ b/src/bb-modules/Client/Api/Guest.php
@@ -91,11 +91,6 @@ class Guest extends \Api_Abstract
             throw new \Box_Exception('Email is already registered. You may want to login instead of registering.');
         }
 
-        $phoneCC = $this->di['array_get']($data, 'phone_cc', $client->phone_cc);
-        if(!empty($phoneCC)){
-            $client->phone_cc = intval($phoneCC);
-        }
-
         $client = $service->guestCreateClient($data);
 
         if (isset($config['require_email_confirmation']) && (int)$config['require_email_confirmation'] && !$client->email_approved) {

--- a/src/bb-modules/Client/Api/Guest.php
+++ b/src/bb-modules/Client/Api/Guest.php
@@ -91,6 +91,11 @@ class Guest extends \Api_Abstract
             throw new \Box_Exception('Email is already registered. You may want to login instead of registering.');
         }
 
+        $phoneCC = $this->di['array_get']($data, 'phone_cc', $client->phone_cc);
+        if(!empty($phoneCC)){
+            $client->phone_cc = intval($phoneCC);
+        }
+
         $client = $service->guestCreateClient($data);
 
         if (isset($config['require_email_confirmation']) && (int)$config['require_email_confirmation'] && !$client->email_approved) {

--- a/src/bb-modules/Client/Service.php
+++ b/src/bb-modules/Client/Service.php
@@ -481,13 +481,17 @@ class Service implements InjectionAwareInterface
         $client->first_name = ucwords($this->di['array_get']($data, 'first_name'));
         $client->pass       = $this->di['password']->hashIt($password);
 
+        $phoneCC = $this->di['array_get']($data, 'phone_cc', $client->phone_cc);
+        if(!empty($phoneCC)){
+            $client->phone_cc = intval($phoneCC);
+        }
+
         $client->aid             = $this->di['array_get']($data, 'aid');
         $client->last_name       = $this->di['array_get']($data, 'last_name');
         $client->client_group_id = $this->di['array_get']($data, 'group_id');
         $client->status          = $this->di['array_get']($data, 'status');
         $client->gender          = $this->di['array_get']($data, 'gender');
         $client->birthday        = $this->di['array_get']($data, 'birthday');
-        $client->phone_cc        = $this->di['array_get']($data, 'phone_cc');
         $client->phone           = $this->di['array_get']($data, 'phone');
         $client->company         = $this->di['array_get']($data, 'company');
         $client->company_vat     = $this->di['array_get']($data, 'company_vat');


### PR DESCRIPTION
Currently, it's possible to submit a phone number country code both with and without a prefixed plus. This tweak filters that plus from the client input, as it clashes with domain registration systems.