### PR TITLE
Send Activation email from scheduler

### DIFF
--- a/src/bb-modules/Order/Service.php
+++ b/src/bb-modules/Order/Service.php
@@ -65,12 +65,11 @@ class Service implements InjectionAwareInterface
 
         try {
             $order = $di['db']->getExistingModelById('ClientOrder', $order_id, 'Order not found');;
-            $identity = $di['loggedin_admin'];
-            $s  = $service->getOrderServiceData($order, $identity);
-            $orderArr = $service->toApiArray($order, true, $identity);
+            $s  = $service->getOrderServiceData($order);
+            $orderArr = $service->toApiArray($order, true);
 
             $email              = $params;
-            $email['to_client'] = $orderArr['client']['id'];
+            $email['to_client'] = $order->client_id;
             $email['code']      = sprintf('mod_service%s_activated', $orderArr['service_type']);
             $email['service']   = $s;
             $email['order']     = $orderArr;
@@ -1263,7 +1262,7 @@ class Service implements InjectionAwareInterface
         return $this->di['db']->findOne('ClientOrder', 'id = :id AND client_id = :client_id', $bindings);
     }
 
-    public function getOrderServiceData(\Model_ClientOrder $order, $identity)
+    public function getOrderServiceData(\Model_ClientOrder $order, $identity = null)
     {
         $orderId = $order->id;
         $service = $this->getOrderService($order);


### PR DESCRIPTION
When an order is activated via the admin page, a correspondent email is sent out to the user, containing the license key (module Servicelicense). However, this is not happening when we pay via Paypal and the order gets automatically activated on the next scheduler run.

The reason being is that the $di ['loggedin_admin'] call throws an exception and the email code does not get executed. In reality we do not need to collect sensitive data, all we need is the client_id which is already present in the $order obejct, therefore we can send out the
email.

This is very important for automatic shops selling license. Although the license can be viewed on the user's Services page, anyone new to BB will interpret as having paid and not received the correspondent key.

See also

http://www.boxbilling.com/forum/boxbilling-support/account-activated-mail-problems-please-help