### PR TITLE
Order Addon onAfterAdminOrderActivate

### DIFF
--- a/src/bb-modules/Order/Service.php
+++ b/src/bb-modules/Order/Service.php
@@ -656,7 +656,7 @@ class Service implements InjectionAwareInterface
             try {
                 $this->di['events_manager']->fire(array('event' => 'onBeforeAdminOrderActivate', 'params' => array('id' => $addon->id)));
                 $this->createFromOrder($addon);
-                $this->di['events_manager']->fire(array('event' => 'onBeforeAdminOrderActivate', 'params' => array('id' => $addon->id)));
+                $this->di['events_manager']->fire(array('event' => 'onAfterAdminOrderActivate', 'params' => array('id' => $addon->id)));
             } catch (\Exception $e) {
                 error_log($e->getMessage());
             }


### PR DESCRIPTION
After addon was activated, callout onBeforeAdminOrderActivate was called
again. As a result, no emails were sent out on (in my case) the
availability of downloadable products. Works in conjunction with #389.