### PR TITLE
Send New Order Placed emails even if Admin not logged in

### DIFF
--- a/src/bb-modules/Order/Service.php
+++ b/src/bb-modules/Order/Service.php
@@ -356,9 +356,10 @@ class Service implements InjectionAwareInterface
             }else{
                 $data['plugin'] = null;
             }
-            $client = $this->di['db']->getExistingModelById('Client', $model->client_id, 'Client not found');
-            $data['client'] = $clientService->toApiArray($client, false);
         }
+
+        $client = $this->di['db']->getExistingModelById('Client', $model->client_id, 'Client not found');
+        $data['client'] = $clientService->toApiArray($client, false);
 
         return $data;
     }

--- a/src/bb-modules/Staff/Service.php
+++ b/src/bb-modules/Staff/Service.php
@@ -133,7 +133,7 @@ class Service implements InjectionAwareInterface
         try {
             $orderModel = $di['db']->load('ClientOrder', $params['id']);
             $orderTicketService = $di['mod_service']('order');
-            $order = $orderTicketService->toApiArray($orderModel, true, $di['loggedin_admin']);
+            $order = $orderTicketService->toApiArray($orderModel, true);
 
             $email = array();
             $email['to_staff']  = true;


### PR DESCRIPTION
A "New Order Placed" email is sent to Admin, but only if is logged in. This patch enables the email to be sent even if Admin is off-line (which in usually the case).  Without this, there is no notification sent about new orders. 

A similar change would be required in Staff/Service.php:onAfterClientOpenTicket in order to receive notifications when a new ticket opened (and Admin is not logged in)
