### PR TITLE
added ORDER BY to public ticket message fetching

### DIFF
--- a/src/bb-modules/Support/Service.php
+++ b/src/bb-modules/Support/Service.php
@@ -1156,12 +1156,12 @@ class Service implements \Box\InjectionAwareInterface
     {
         $data        = $this->di['db']->toArray($model);
         $messages    = array();
-        $messagesArr = $this->di['db']->find('SupportPTicketMessage', 'support_p_ticket_id = :support_p_ticket_id', array(':support_p_ticket_id' => $model->id));
+        $messagesArr = $this->di['db']->find('SupportPTicketMessage', 'support_p_ticket_id = :support_p_ticket_id ORDER BY id', array(':support_p_ticket_id' => $model->id));
         foreach ($messagesArr as $msg) {
             $messages[] = $this->publicMessageToApiArray($msg);
         }
 
-        $first = $this->di['db']->findOne('SupportPTicketMessage', 'support_p_ticket_id = :support_p_ticket_id LIMIT 1', array(':support_p_ticket_id' => $model->id));
+        $first = reset($messagesArr);
         if ($first instanceof \Model_SupportPTicketMessage) {
             $data['author'] = $this->publicMessageGetAuthorDetails($first);
         } else {


### PR DESCRIPTION
I experienced problems in viewing public tickets. Tickets would not appear in the correct order, both in the frontend as well as bb-admin. I've added an ORDER BY clause to fix this problem.

Additionally, I saved one query to retrieve the first ticket.