### PR TITLE
Search Client Login History Fix

### DIFF
--- a/src/bb-modules/Client/Service.php
+++ b/src/bb-modules/Client/Service.php
@@ -281,9 +281,9 @@ class Service implements InjectionAwareInterface
         $where = array();
         $params = array();
         if($search) {
-            $where[] = 'c.first_name LIKE %:first_name% OR c.last_name LIKE %:last_name% OR c.id LIKE :id';
-            $params[':first_name'] = $search;
-            $params[':last_name'] = $search;
+            $where[] = 'c.first_name LIKE :first_name OR c.last_name LIKE :last_name OR c.id LIKE :id';
+            $params[':first_name'] = "%".$search."%";
+            $params[':last_name'] = "%".$search."%";
             $params[':id'] = $search;
         }
 


### PR DESCRIPTION
In Activity/Client logins history, performing a search using the box at the top right corner throw a SQL error. Small fix to make search works