### PR TITLE
Domain renewal BUG FIX

### DIFF
--- a/src/bb-modules/Servicedomain/Service.php
+++ b/src/bb-modules/Servicedomain/Service.php
@@ -260,7 +260,11 @@ class Service implements \Box\InjectionAwareInterface
         list($domain, $adapter) = $this->_getD($model);
         $adapter->renewDomain($domain);
 
-        $this->syncWhois($model, $order);
+        try {
+            $this->syncWhois($model, $order);
+        } catch (\Exception $e) {
+            error_log($e->getMessage());
+        }
 
         return true;
     }


### PR DESCRIPTION
Domain renewal bug fix - "Serialization of 'SimpleXMLElement' is not allowed"
This causes renewal problem with SOME registrar modules because it produces output before headers.