### PR TITLE
Move issue from CircleBilling to BoxBilling (SQLSTATE[42000]: Syntax error or access violation)

### DIFF
--- a/src/bb-modules/Product/Service.php
+++ b/src/bb-modules/Product/Service.php
@@ -749,14 +749,25 @@ class Service implements InjectionAwareInterface
 
     public function getProductCategorySearchQuery($data)
     {
-        $sql = "SELECT m.*
-                FROM product_category as m
-                  LEFT JOIN product p on p.product_category_id = m.id
-                WHERE p.status = 'enabled'
-                  AND p.hidden = 0
-                GROUP BY p.product_category_id
-                ORDER BY p.priority ASC
-        ";
+        $sql = 'SELECT m.id, 
+                       m.title, 
+                       m.description, 
+                       m.icon_url, 
+                       m.created_at, 
+                       m.updated_at, 
+                       Max(p.priority) AS MaxPrio
+                FROM   product_category AS m 
+                       LEFT JOIN product p 
+                              ON p.product_category_id = m.id 
+                WHERE  p.status = \'enabled\' 
+                       AND p.hidden = 0 
+                GROUP  BY m.id, 
+                          m.title, 
+                          m.description, 
+                          m.icon_url, 
+                          m.created_at, 
+                          m.updated_at 
+                ORDER  BY MaxPrio ASC;';
 
         $params = array();
 


### PR DESCRIPTION
Hi,
to de-escalate the current situation between BoxBilling and CircleBilling we're agreed to share some fixed to BoxBilling.

This bug is about a bad written SQL Query. I got a mysql exception (src/bb-modules/Product/Service.php:752):
> An exception has been thrown during the rendering of a template ("SQLSTATE[42000]: Syntax error or access violation: 1055 Expression # 1 of ORDER BY clause is not in GROUP BY clause and contains nonaggregated column 'circlebilling.p.priority' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by") in "mod_order_index.phtml" at line 20.

You can find more informations about that issue here: https://github.com/CircleBilling/CircleBilling/issues/7
