### PR TITLE
After purchasing hosting plan, 'Jump to cPanel' link changes

### DIFF
--- a/src/bb-modules/Servicehosting/Service.php
+++ b/src/bb-modules/Servicehosting/Service.php
@@ -456,6 +456,7 @@ class Service implements InjectionAwareInterface
             'sld'           =>  $model->sld,
             'tld'           =>  $model->tld,
             'domain'        =>  $model->sld.$model->tld,
+			'cpanel_url'    =>  'http://' . ($model->sld.$model->tld ? $model->sld.$model->tld : $model->ip) . '/cpanel',
             'username'      =>  $model->username,
             'reseller'      =>  $model->reseller,
             'server'        =>  $server,

--- a/src/bb-modules/Servicehosting/html_client/mod_servicehosting_manage.phtml
+++ b/src/bb-modules/Servicehosting/html_client/mod_servicehosting_manage.phtml
@@ -66,7 +66,7 @@
                             {% if service.domain_order_id %}
                                     <a class="btn btn-primary" href="{{ '/order/service/manage'|link }}/{{service.domain_order_id}}">{% trans 'Manage domain' %}</a>
                             {% endif %}
-                                    <a class="btn btn-primary" href="{{ server.cpanel_url }}" target="_blank">{% trans 'Jump to cPanel' %}</a>
+                                    <a class="btn btn-primary" href="{{ service.cpanel_url }}" target="_blank">{% trans 'Jump to cPanel' %}</a>
                             {% if service.reseller %}
                                     <a class="btn btn-primary" href="{{ server.reseller_cpanel_url }}" target="_blank">{% trans 'Reseller control panel' %}</a>
                             {% endif %}


### PR DESCRIPTION
After purchasing hosting plan, 'Jump to cPanel' link should point to the domain name attached to hosting plan or IP address

For example if I have purchased a hosting plan and given domain name `xyz.co` then cpanle url for client should be `http://xyx.co/cpanel` instead of host name of reseller.