### PR TITLE
Update .htaccess of bb-uploads for better security and better compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,6 @@ matrix:
 
 sudo: false
 
-install:
-  - composer self-update
-  - composer install
-
 before_script:
   - mysql --user=root -e "CREATE USER 'foo'@'localhost' IDENTIFIED BY 'foo';"
   - mysql --user=root -e "GRANT ALL PRIVILEGES ON *.* TO 'foo'@'localhost'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: php
 
+dist: trusty
+
 php:
   - 5.3
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
 
 sudo: false
 
+install:
+  - composer self-update
+
 before_script:
   - mysql --user=root -e "CREATE USER 'foo'@'localhost' IDENTIFIED BY 'foo';"
   - mysql --user=root -e "GRANT ALL PRIVILEGES ON *.* TO 'foo'@'localhost'"
@@ -30,7 +33,7 @@ before_script:
   - mv ./src/bb-config-sample.php ./src/bb-config.php
 
 script:
-  - src/bb-vendor/bin/phpunit
+  - ./src/bb-vendor/bin/phpunit
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: php
 dist: trusty
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -22,7 +21,10 @@ matrix:
 sudo: false
 
 install:
+  - ant
   - composer self-update
+  - composer require --dev phpunit/phpunit ^6.0 php-coveralls/php-coveralls ^2.1
+  - composer install --dev
 
 before_script:
   - mysql --user=root -e "CREATE USER 'foo'@'localhost' IDENTIFIED BY 'foo';"
@@ -33,8 +35,28 @@ before_script:
   - mv ./src/bb-config-sample.php ./src/bb-config.php
 
 script:
-  - ./src/bb-vendor/bin/phpunit
+  - ./vendor/bin/phpunit --coverage-clover ./tests/logs/clover.xml
+
+after_script:
+  - php vendor/bin/coveralls -v
 
 notifications:
   email: false
   slack: boxbilling:vsdKszFU9Pm308ye5rNSpr8n
+
+before_deploy:
+  - npm install -g grunt-cli
+  - npm install
+  - grunt
+  - ant release
+
+deploy:
+  provider: releases
+  api-key:
+    secure: tVzZ+3U0ndBGvoUpFqA6ikg6fDKnPgMoNqK1pvTdEp0xmrFtjMP/fuc8+awObhj89iEC+MyzfsOP57CZbHR/UjmUSHPQew+BvTwxYmTUzgUeyUrYsTEI7WJgB7tsL35aRgrpxk102tlSmlX7EonufUT0svPOAQ1p4NgZRm3GI3A=
+  file: ./build/distribution/BoxBilling.zip
+  skip_cleanup: true
+  on:
+    tags: true
+    all_branches: true
+    php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,49 +10,32 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
+  - 7.2
 
 matrix:
   allow_failures:
-    - php: hhvm
     - php: 7.0
+    - php: 7.1
+    - php: 7.2
 
 sudo: false
 
 install:
   - composer self-update
-  - composer require 'satooshi/php-coveralls:0.7.*@dev'
+  - composer install
 
 before_script:
   - mysql --user=root -e "CREATE USER 'foo'@'localhost' IDENTIFIED BY 'foo';"
   - mysql --user=root -e "GRANT ALL PRIVILEGES ON *.* TO 'foo'@'localhost'"
   - mysql -e 'create database IF NOT EXISTS boxbilling'
+  - mysql -D boxbilling < src/install/structure.sql
+  - mysql -D boxbilling < src/install/content.sql
+  - mv ./src/bb-config-sample.php ./src/bb-config.php
 
 script:
-  - ant
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then src/bb-vendor/bin/phpunit --coverage-clover=build/logs/clover.xml tests/; fi;'
-
-after_script:
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then php vendor/bin/coveralls -v; fi;'
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi;'
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi;'
+  - ./src/bb-vendor/bin/phpunit
 
 notifications:
   email: false
   slack: boxbilling:vsdKszFU9Pm308ye5rNSpr8n
-
-before_deploy:
-  - npm install -g grunt-cli
-  - npm install
-  - grunt
-  - ant release
-deploy:
-  provider: releases
-  api-key:
-    secure: tVzZ+3U0ndBGvoUpFqA6ikg6fDKnPgMoNqK1pvTdEp0xmrFtjMP/fuc8+awObhj89iEC+MyzfsOP57CZbHR/UjmUSHPQew+BvTwxYmTUzgUeyUrYsTEI7WJgB7tsL35aRgrpxk102tlSmlX7EonufUT0svPOAQ1p4NgZRm3GI3A=
-  file: ./build/distribution/BoxBilling.zip
-  skip_cleanup: true
-  on:
-    tags: true
-    all_branches: true
-    php: 5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - mv ./src/bb-config-sample.php ./src/bb-config.php
 
 script:
-  - ./src/bb-vendor/bin/phpunit
+  - src/bb-vendor/bin/phpunit
 
 notifications:
   email: false

--- a/src/bb-uploads/.htaccess
+++ b/src/bb-uploads/.htaccess
@@ -1,2 +1,5 @@
-php_flag engine off
+<Files *>
+    SetHandler default-handler
+</Files>
 Options -Indexes
+AllowOverride None


### PR DESCRIPTION
For most shared MultiPHP hostings the `php_flag engine off` won't work and this creates a big security flaw, instead of that we can set handler for all files under bb-upload directory to the default one, also added `AllowOverride None` to prevent uploading .htaccess file in a subdirectory to override this one.