### PR TITLE
Use invoice item quantity to correctly calculate discounts and taxes

### DIFF
--- a/src/bb-library/Box/TwigExtensions.php
+++ b/src/bb-library/Box/TwigExtensions.php
@@ -255,7 +255,7 @@ function twig_size_filter($value)
     return round($bytes, $precision) . ' ' . $units[$pow];
 }
 
-function twig_markdown_filter(Twig_Environment $env, $value)
+function twig_markdown_filter(Twig\Environment $env, $value)
 {
     $markdownParser = new \Michelf\MarkdownExtra;
     // Michelf Markdown version 1.7.0 and up
@@ -263,7 +263,7 @@ function twig_markdown_filter(Twig_Environment $env, $value)
     return $markdownParser->transform($value); //htmlspecialchars($value, ENT_NOQUOTES)
 }
 
-function twig_truncate_filter(Twig_Environment $env, $value, $length = 30, $preserve = false, $separator = '...')
+function twig_truncate_filter(Twig\Environment $env, $value, $length = 30, $preserve = false, $separator = '...')
 {
     mb_internal_encoding("UTF-8");
     if (mb_strlen($value) > $length) {
@@ -282,7 +282,7 @@ function twig_truncate_filter(Twig_Environment $env, $value, $length = 30, $pres
 /**
  * BoxBilling markdown
  */
-function twig_bbmd_filter(Twig_Environment $env, $value)
+function twig_bbmd_filter(Twig\Environment $env, $value)
 {
     $value = twig_markdown_filter($env, $value);
     return $value;

--- a/src/bb-library/Payment/Invoice/Item.php
+++ b/src/bb-library/Payment/Invoice/Item.php
@@ -124,6 +124,6 @@ class Payment_Invoice_Item
 
     public function getTotalWithTax()
     {
-        return $this->getTotal() + $this->getQuantity() * $this->getTax();
+        return $this->getTotal() + $this->getTax();
     }
 }

--- a/src/bb-modules/Order/Service.php
+++ b/src/bb-modules/Order/Service.php
@@ -1062,15 +1062,15 @@ class Service implements InjectionAwareInterface
     public function rmInvoiceItemByOrder(\Model_ClientOrder $order)
     {
         $bindings = array(
-            ':type'   => 'order',
             ':rel_id' => $order->id,
             ':status' => \Model_InvoiceItem::STATUS_PENDING_PAYMENT
         );
 
-        $item = $this->di['db']->findOne('InvoiceItem', 'type = :type AND rel_id = :rel_id AND status = :status', $bindings);
-
+        $items = $this->di['db']->find('InvoiceItem', 'rel_id = :rel_id AND status = :status', $bindings);
+        foreach($items as $item){
         if ($item instanceof \Model_InvoiceItem) {
             $this->di['db']->trash($item);
+            }
         }
     }
 

--- a/src/bb-modules/Product/Service.php
+++ b/src/bb-modules/Product/Service.php
@@ -962,6 +962,7 @@ class Service implements InjectionAwareInterface
         }
 
         $discount = 0;
+        $quantity = 1;
 
         switch ($promo->type) {
             case \Model_Promo::ABSOLUTE:
@@ -969,7 +970,12 @@ class Service implements InjectionAwareInterface
                 break;
 
             case \Model_Promo::PERCENTAGE:
-                $discount += round(($price * $promo->value / 100), 2);
+
+                if(isset($config['quantity']) && is_numeric($config['quantity'])){
+                    $quantity = $config['quantity'];
+                }
+                
+                $discount += round(($price * $quantity * $promo->value / 100), 2);
                 break;
 
             default:

--- a/src/bb-modules/Support/Service.php
+++ b/src/bb-modules/Support/Service.php
@@ -548,6 +548,7 @@ class Service implements \Box\InjectionAwareInterface
         $data['replies']  = $this->messageGetRepliesCount($model);
         $data['first']    = $this->messageToApiArray($firstSupportTicketMessage);
         $data['helpdesk'] = $this->helpdeskToApiArray($supportHelpdesk);
+        $data['client']     = $this->getClientApiArrayForTicket($model);
 
         if ($deep) {
             $messages = $this->messageGetTicketMessages($model);
@@ -559,7 +560,6 @@ class Service implements \Box\InjectionAwareInterface
         if ($identity instanceof \Model_Admin) {
             $data['rel']        = $this->_getRelDetails($model);
             $data['priority']   = $model->priority;
-            $data['client']     = $this->getClientApiArrayForTicket($model);
             $supportTicketNotes = $this->di['db']->find('SupportTicketNote', 'support_ticket_id = :support_ticket_id', array(':support_ticket_id' => $model->id));
 
             foreach ($supportTicketNotes as $note) {

--- a/src/bb-themes/boxbilling/html/mod_cart_index.phtml
+++ b/src/bb-themes/boxbilling/html/mod_cart_index.phtml
@@ -42,10 +42,10 @@
                         <td>{{ item.period | period_title }}</td>
                         <td class="currency">
                             {% if item.discount_price %}
-                                <del>{{ (item.price*item.quantity)  | money_convert }}</del>
-                                {{ (item.price*item.quantity - item.discount_price*item.quantity) | money_convert }}
+                                <del>{{ (item.total)  | money_convert }}</del>
+                                {{ (item.total - item.discount_price) | money_convert }}
                             {% else %}
-                                {{ item.price | money_convert }}
+                                {{ (item.total) | money_convert }}
                             {% endif %}
                         </td>
                     </tr>
@@ -96,11 +96,9 @@
                             <div class="currency">{{ tax_amount | money_convert }}</div>
                         {% endif %}
                         <p>{% trans 'Total:' %}</p>
-                        <div class="currency">{% if cart.items[1].quantity > 1 and cart.items[1].discount_price%}
-	{{ (cart.total - (cart.items[1].price*(cart.items[1].quantity-1))) | money_convert }}
-    {%else%}
-	{{(cart.total + tax_amount) | money_convert }}
-	{%endif%}</div>
+                        <div class="currency">
+							{{(cart.total + tax_amount) | money_convert }}
+	                    </div>
                         <form method="post" action="{{ 'api/client/cart/checkout'|link }}" class="api-form" data-api-jsonp="onAfterCartCheckout">
                         {% set enough_in_balance = client.client_balance_get_total >= cart.total %}
                         {% if cart.total and not enough_in_balance  %}


### PR DESCRIPTION
Issue:
Boxbilling does not have a table column for storing discount for invoice item. An item's discount can only be used in a cart while placing an order. After checkout, the discount is stored for the order and not the individual items.  As a result there isn't any way to determine whether an item was discounted when fetching invoice as an array (including items). 

Fix:
This pull request fixes #616 by adding discounts as invoice items and using the item quantity to calculate the item's total price and also correctly calculate taxes on invoice total.