### PR TITLE
Add missing PHPMailer namespaces

### DIFF
--- a/src/bb-library/Box/Mail.php
+++ b/src/bb-library/Box/Mail.php
@@ -27,6 +27,10 @@
  * @license   http://www.boxbilling.com/LICENSE.txt
  * @version   $Id$
  */
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
 class Box_Mail
 {
     private $_bodyHtml  = NULL;


### PR DESCRIPTION
Without these sending emails from the app will not work and will throw missing class exceptions.