### PR TITLE
Removed license key from example config file

### DIFF
--- a/src/bb-config-sample.php
+++ b/src/bb-config-sample.php
@@ -15,7 +15,7 @@ return array(
     /**
      * Set BoxBilling license key. Get license key at http://www.boxbilling.com
      */
-    'license'     => 'PRO-wfe1RJ6aqG1wurwlocc9lwouNeTcUtklsp9ujy33clb8c57fdV',
+    'license'     => '',
 
     'salt'        => '',
 


### PR DESCRIPTION
Why does the example config file contain a legit license key? If this wasn't made intentionally, this should be removed.