### PR TITLE
Enable Admin theme selection

### DIFF
--- a/src/bb-modules/Extension/Api/Guest.php
+++ b/src/bb-modules/Extension/Api/Guest.php
@@ -41,10 +41,10 @@ class Guest extends \Api_Abstract
      * Return active theme info
      * @return array
      */
-    public function theme()
+    public function theme($client = true)
     {
         $systemService = $this->di['mod_service']('theme');
-        return $systemService->getThemeConfig(true, null);
+        return $systemService->getThemeConfig($client, null);
     }
 
     /**

--- a/src/bb-modules/Theme/Api/Admin.php
+++ b/src/bb-modules/Theme/Api/Admin.php
@@ -24,6 +24,17 @@ class Admin extends \Api_Abstract
         $themes = $this->getService()->getThemes();
         return array('list'=>$themes);
     }
+    
+    /**
+     * Get list of available admin area themes
+     * 
+     * @return array 
+     */
+    public function get_admin_list($data)
+    {
+        $themes = $this->getService()->getThemes(false);
+        return array('list'=>$themes);
+    }
 
     /**
      * Get theme by code

--- a/src/bb-modules/Theme/html_admin/mod_theme_settings.phtml
+++ b/src/bb-modules/Theme/html_admin/mod_theme_settings.phtml
@@ -29,11 +29,52 @@
         {% for i, theme in themes.list %}
 
         <tr>
-            <td>{% if guest.extension_theme.code == theme.code %}<strong>{{ theme.code }}</strong>{% else %}{{ theme.code }}{% endif %}</td>
+            <td>{% if guest.extension_theme(true).code == theme.code %}<strong>{{ theme.code }}</strong>{% else %}{{ theme.code }}{% endif %}</td>
             <td class="actions">
                 <a class="btnIconLeft mr10" href="{{ 'theme'|alink }}/{{theme.code}}"><img src="images/icons/dark/cog.png" alt="" class="icon"><span>{% trans 'Settings' %}</span></a>
-                {% if guest.extension_theme.code != theme.code %}
+                {% if guest.extension_theme(true).code != theme.code %}
                 <a class="btnIconLeft mr10 api-link" data-api-redirect="{{ 'extension/settings/theme'|alink }}" href="{{ 'api/admin/theme/select'|link({'code' : theme.code}) }}"><img src="images/icons/dark/star.png" alt="" class="icon"><span>{% trans 'Set as default' %}</span></a>
+                {% endif %}
+            </td>
+        </tr>
+        </tbody>
+
+        {% else %}
+        <tbody>
+        <tr>
+            <td colspan="5">
+                {% trans 'The list is empty' %}
+            </td>
+        </tr>
+        </tbody>
+        {% endfor %}
+    </table>
+
+</div>
+
+<div class="widget">
+    <div class="head"><h5 class="iPaintBrush">{% trans 'Admin area themes' %}</h5></div>
+
+    <table class="tableStatic wide">
+        <thead>
+        <tr>
+            <td>{% trans 'Name' %}</td>
+            <td>{% trans 'Actions' %}</td>
+        </tr>
+        </thead>
+
+        <tbody>
+        {% set themes = admin.theme_get_admin_list({"per_page":100}) %}
+        {% for i, theme in themes.list %}
+
+        <tr>
+            <td>{% if guest.extension_theme(false).code == theme.code %}<strong>{{ theme.code|replace({'admin_': ''}) }}</strong>{% else %}{{ theme.code|replace({'admin_': ''})  }}{% endif %}</td>
+            <td class="actions">
+                <a class="btnIconLeft mr10" href="{{ 'theme'|alink }}/{{theme.code}}"><img src="images/icons/dark/cog.png" alt="" class="icon"><span>{% trans 'Settings' %}</span></a>
+                {% if guest.extension_theme(false).code != theme.code %}
+                <a class="btnIconLeft mr10 api-link" data-api-redirect="{{ 'extension/settings/theme'|alink }}" href="{{ 'api/admin/theme/select'|link({'code' : theme.code}) }}">
+                    <img src="images/icons/dark/star.png" alt="" class="icon"><span>{% trans 'Set as default' %}</span>
+                </a>
                 {% endif %}
             </td>
         </tr>


### PR DESCRIPTION
Enable people to select an admin theme.

This will allow #663 to create a seperate theme instead of overwriting the default admin theme