### PR TITLE
Redirect to login page if client or admin is not logged in

### DIFF
--- a/src/bb-di.php
+++ b/src/bb-di.php
@@ -168,16 +168,36 @@ $di['twig'] = $di->factory(function () use ($di) {
 
 $di['is_client_logged'] = function() use($di) {
     if(!$di['auth']->isClientLoggedIn()) {
-        $url = $di['url']->link('login');
-        header("Location: $url");  
-        throw new Exception('Client is not logged in');
+        $api_str = '/api/';
+        $url = $di['request']->getQuery('_url');
+        if (strncasecmp($url, $api_str , strlen($api_str)) === 0) {
+            //Throw Exception if api request
+            throw new Exception('Client is not logged in');
+        }
+        else {            
+            //Redirect to login page if browser request
+            $login_url = $di['url']->link('login');
+            header("Location: $login_url");
+        }
+
     }
     return true;
 };
 
 $di['is_admin_logged'] = function() use($di) {
+    
     if(!$di['auth']->isAdminLoggedIn()) {
+    $api_str = '/api/';
+    $url = $di['request']->getQuery('_url');
+    if (strncasecmp($url, $api_str , strlen($api_str)) === 0) {
+        //Throw Exception if api request
         throw new Exception('Admin is not logged in');
+    }
+    else {
+        //Redirect to login page if browser request
+        $login_url = $di['url']->adminLink('staff/login');
+        header("Location: $login_url");
+        }
     }
     return true;
 };

--- a/src/bb-modules/System/Service.php
+++ b/src/bb-modules/System/Service.php
@@ -285,6 +285,7 @@ class Service
     public function renderString($tpl, $try_render, $vars)
     {
         $twig = $this->di['twig'];
+        //add client api if _client_id is set
         if(isset($vars['_client_id'])) {
             $identity = $this->di['db']->load('Client', $vars['_client_id']);
             if($identity instanceof \Model_Client) {
@@ -296,11 +297,13 @@ class Service
                 }
             }
         }
-
+        else{
+            // attempt adding admin api to twig
         try {
             $twig->addGlobal('admin', $this->di['api_admin']);
         } catch(\Exception $e) {
             //skip if admin is not logged in
+        }
         }
 
         try {


### PR DESCRIPTION
When accessing a restricted page, boxbilling is redirected to the error page when client or admin is not logged in.

This PR redirects admin or client to login page when the request is made from a browser and throws an exception when the request is an API request.