### PR TITLE
Fix: registrar adapter doesn't work in debug mode

### DIFF
--- a/src/bb-modules/Invoice/Service.php
+++ b/src/bb-modules/Invoice/Service.php
@@ -1136,6 +1136,11 @@ class Service implements InjectionAwareInterface
         if (method_exists($adapter, 'setDi')) {
             $adapter->setDi($this->di);
         }
+        
+        if (method_exists($adapter, 'setLog')) {
+            $adapter->setLog($this->di['logger']);
+        }
+
         $pgc = $adapter->getConfig();
 
         //@since v2.9.15

--- a/src/bb-modules/Servicedomain/Service.php
+++ b/src/bb-modules/Servicedomain/Service.php
@@ -970,7 +970,8 @@ class Service implements \Box\InjectionAwareInterface
         if (!$registrar instanceof \Registrar_AdapterAbstract) {
             throw new \Box_Exception('Registrar adapter :adapter should extend Registrar_AdapterAbstract', array(':adapter' => $class));
         }
-
+        
+        $registrar->setLog($this->di['logger']);
 
         if (isset($r->test_mode) && $r->test_mode) {
             $registrar->enableTestMode();


### PR DESCRIPTION
Box_log requires $di injection but registrar adapters do not implement Box\InjectionAwareInterface so a log service has to be set after creating an instance of an adapter.