### PR TITLE
Remove all entities of license checking.

### DIFF
--- a/src/install/index.php
+++ b/src/install/index.php
@@ -215,14 +215,6 @@ final class Box_Installer
         return true;
     }
 
-    private function isValidLicense($license)
-    {
-        if (empty($license)) {
-            return false;
-        }
-        return true;
-    }
-
     private function checkConfig()
     {
         if (!file_exists(BB_PATH_CONFIG)) {


### PR DESCRIPTION
See [this automatic report created by Scrutinizer](https://scrutinizer-ci.com/g/boxbilling/boxbilling/inspections/83cb3009-e70d-4f5e-b321-6cb9bcb50edf/issues/files/src/install/index.php?status=new&orderField=path&order=asc&honorSelectedPaths=0). The `isValidLicense()` function is not being used in anywhere of the code, and since we won't have licensing in the near future, we can remove it.