### PR TITLE
Methods with the same name as their class should not be constructors

### DIFF
--- a/src/bb-library/php-gettext/gettext.php
+++ b/src/bb-library/php-gettext/gettext.php
@@ -98,7 +98,7 @@ class gettext_reader {
    * @param object Reader the StreamReader object
    * @param boolean enable_cache Enable or disable caching of strings (default on)
    */
-  function gettext_reader($Reader, $enable_cache = true) {
+  function __construct($Reader, $enable_cache = true) {
     // If there isn't a StreamReader, turn on short circuit mode.
     if (! $Reader || isset($Reader->error) ) {
       $this->short_circuit = true;

--- a/src/bb-library/php-gettext/gettext.php
+++ b/src/bb-library/php-gettext/gettext.php
@@ -98,7 +98,7 @@ class gettext_reader {
    * @param object Reader the StreamReader object
    * @param boolean enable_cache Enable or disable caching of strings (default on)
    */
-  function __construct($Reader, $enable_cache = true) {
+  public function __construct($Reader, $enable_cache = true) {
     // If there isn't a StreamReader, turn on short circuit mode.
     if (! $Reader || isset($Reader->error) ) {
       $this->short_circuit = true;

--- a/src/bb-library/php-gettext/streams.php
+++ b/src/bb-library/php-gettext/streams.php
@@ -49,7 +49,7 @@ class StringReader {
   var $_pos;
   var $_str;
 
-  function StringReader($str='') {
+  function __construct($str='') {
     $this->_str = $str;
     $this->_pos = 0;
   }
@@ -86,7 +86,7 @@ class FileReader {
   var $_fd;
   var $_length;
 
-  function FileReader($filename) {
+  function __construct($filename) {
     if (file_exists($filename)) {
 
       $this->_length=filesize($filename);
@@ -143,7 +143,7 @@ class FileReader {
 // Preloads entire file in memory first, then creates a StringReader
 // over it (it assumes knowledge of StringReader internals)
 class CachedFileReader extends StringReader {
-  function CachedFileReader($filename) {
+  function __construct($filename) {
     if (file_exists($filename)) {
 
       $length=filesize($filename);

--- a/src/bb-library/php-gettext/streams.php
+++ b/src/bb-library/php-gettext/streams.php
@@ -49,7 +49,7 @@ class StringReader {
   var $_pos;
   var $_str;
 
-  function __construct($str='') {
+  public function __construct($str='') {
     $this->_str = $str;
     $this->_pos = 0;
   }
@@ -86,7 +86,7 @@ class FileReader {
   var $_fd;
   var $_length;
 
-  function __construct($filename) {
+  public function __construct($filename) {
     if (file_exists($filename)) {
 
       $this->_length=filesize($filename);
@@ -143,7 +143,7 @@ class FileReader {
 // Preloads entire file in memory first, then creates a StringReader
 // over it (it assumes knowledge of StringReader internals)
 class CachedFileReader extends StringReader {
-  function __construct($filename) {
+  public function __construct($filename) {
     if (file_exists($filename)) {
 
       $length=filesize($filename);


### PR DESCRIPTION
This PR fixes #719, Methods with the same name as their class will not be constructors in a future version of PHP. They should be declared as "__construct()" instead.