### PR TITLE
We can use Ubuntu 20.04 (Focal Fossa) instead of 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-dist: xenial
 os: linux
+dist: focal
 language: shell
 services:
   - docker


### PR DESCRIPTION
We can (and should) use Ubuntu 20.04 (Focal Fossa) instead of 16.04 for Travis. That's newer.