### PR TITLE
A brand new error page, some enhancements to the loader

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -43,6 +43,7 @@ jobs:
         echo > ./src/bb-data/log/license.log
         echo > ./src/bb-data/log/application.log
         echo > ./src/bb-data/log/php_error.log
+        rm -rf ./src/install
     
     - name: Run test suite for bb-modules
       run: |

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ test: start	## Run app tests
 	echo "Running unit tests"
 	echo > ./src/bb-data/log/application.log
 	echo > ./src/bb-data/log/php_error.log
+	rm -rf src/install
 	$(DOCKER_PHP_CONTAINER_EXEC) composer install --working-dir=src --no-progress --no-suggest --prefer-dist
 	$(DOCKER_PHP_CONTAINER_EXEC) ./src/bb-vendor/bin/phpunit --dont-report-useless-tests ./tests/bb-modules/
 

--- a/src/bb-load.php
+++ b/src/bb-load.php
@@ -231,6 +231,11 @@ if(!file_exists($configPath) || 0 == filesize( $configPath )) {
     throw new Exception($msg, 101);
 }
 
+// Try to check if /install directory still exists, even after the installation was completed
+if(file_exists($configPath) && 0 !== filesize($configPath) && file_exists(BB_PATH_ROOT.'/install/index.php')) {
+    throw new Exception("For safety reasons, you have to delete the <b><em>/install</em></b> directory to start using BoxBilling.</p><p>Please delete the <b><em>/install</em></b> directory from your web server.", 102);
+}
+
 $config = require_once $configPath;
 require BB_PATH_VENDOR . '/autoload.php';
 

--- a/src/bb-load.php
+++ b/src/bb-load.php
@@ -224,7 +224,7 @@ if(!file_exists($configPath) || 0 == filesize( $configPath )) {
     @file_put_contents($configPath, '');
     
     $base_url = "http://".$_SERVER['HTTP_HOST'];
-    $base_url .= preg_replace('@/+$@','',dirname($_SERVER['SCRIPT_NAME'])).'/';
+    $base_url .= preg_replace('@/+$@','',dirname($_SERVER['SCRIPT_NAME']));
     $url = $base_url . 'install/index.php';
     $configFile = pathinfo($configPath, PATHINFO_BASENAME);
     $msg = sprintf("The <em>$configFile</em> path seems to be invalid. You may have not generated the configuration file yet, or the configuration file may not contain the required configuration parameters. BoxBilling needs to have a valid configuration file present in order to function properly.</p><p>Need some help with the installation? <a target='_blank' href='http://docs.boxbilling.com/en/latest/reference/installation.html'>We got it</a>. You can create the configuration file using the interactive installer, or manually create the configuration file.</p><p>If it's your first time setting up BoxBilling, you can <a href='%s' class='button'>continue with the web-based interactive BoxBilling installation</a>.", $url);

--- a/src/bb-load.php
+++ b/src/bb-load.php
@@ -183,7 +183,7 @@ function handler_exception($e)
         print sprintf('<h2>Error code: <em>%s</em></h1>', $e->getCode());
     }
     print sprintf('<p>%s</p>', $e->getMessage());
-    print sprintf('<p><a href="http://docs.boxbilling.com/en/latest/search.html?q=%s&check_keywords=yes&area=default" target="_blank">Look for detailed error explanation</a></p>', urlencode($e->getMessage()));
+    print sprintf('<center><p><a href="http://docs.boxbilling.com/en/latest/search.html?q=%s&check_keywords=yes&area=default" target="_blank">Look for detailed error explanation</a></p></center>', urlencode($e->getMessage()));
 
     if(defined('BB_DEBUG') && BB_DEBUG) {
         print sprintf('<em>%s</em>', 'Set BB_DEBUG to FALSE, to hide the message below');
@@ -227,7 +227,7 @@ if(!file_exists($configPath) || 0 == filesize( $configPath )) {
     $base_url .= preg_replace('@/+$@','',dirname($_SERVER['SCRIPT_NAME'])).'/';
     $url = $base_url . 'install/index.php';
     $configFile = pathinfo($configPath, PATHINFO_BASENAME);
-    $msg = sprintf("The <em>$configFile</em> path seems to be invalid. You may have not generated the configuration file yet, or the configuration file may not contain the required configuration parameters. BoxBilling needs to have a valid configuration file present in order to function properly. Need some help with the installation? <a target='_blank' href='http://docs.boxbilling.com/en/latest/reference/installation.html'>We got it</a>. You can create the configuration file using the interactive installer, or manually create the configuration file.</p><p>If it's your first time setting up BoxBilling, you can <a href='%s' class='button'>continue with the web-based interactive BoxBilling installation</a>.", $url);
+    $msg = sprintf("The <em>$configFile</em> path seems to be invalid. You may have not generated the configuration file yet, or the configuration file may not contain the required configuration parameters. BoxBilling needs to have a valid configuration file present in order to function properly.</p><p>Need some help with the installation? <a target='_blank' href='http://docs.boxbilling.com/en/latest/reference/installation.html'>We got it</a>. You can create the configuration file using the interactive installer, or manually create the configuration file.</p><p>If it's your first time setting up BoxBilling, you can <a href='%s' class='button'>continue with the web-based interactive BoxBilling installation</a>.", $url);
     throw new Exception($msg, 101);
 }
 

--- a/src/bb-load.php
+++ b/src/bb-load.php
@@ -47,18 +47,140 @@ function handler_exception($e)
     }
 
     $page = "<!DOCTYPE html>
-    <html lang=en>
-    <meta charset=utf-8>
-    <title>Error</title>
-    <style>
-    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;min-height:180px;padding:30px 0 15px}* > body{padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0} em{font-weight:bold}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}pre{ width: 100%; overflow:auto; }
-    </style>
-    <a href=//www.boxbilling.com/ target='_blank'><img src='/bb-themes/boxbilling/assets/images/logo.png' alt='BoxBilling' style='height:60px'></a>
-    ";
+    <html lang=\"en\">
+    
+    <head>
+        <meta charset=\"utf-8\">
+        <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">
+        <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+        <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    
+        <title>An error ocurred</title>
+    
+        <!-- Google font -->
+        <link href=\"https://fonts.googleapis.com/css?family=Nunito:400,700\" rel=\"stylesheet\">
+    
+        <!-- Custom stlylesheet -->
+        <link type=\"text/css\" rel=\"stylesheet\" href=\"css/style.css\" />
+    
+        <!--[if lt IE 9]>
+            <script src=\"https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js\"></script>
+            <script src=\"https://oss.maxcdn.com/respond/1.4.2/respond.min.js\"></script>
+        <![endif]-->
+        <style>
+        * {
+            -webkit-box-sizing: border-box;
+                    box-sizing: border-box;
+          }
+          
+          body {
+            padding: 0;
+            margin: 0;
+          }
+          
+          #notfound {
+            position: relative;
+            height: 100vh;
+          }
+          
+          #notfound .notfound {
+            position: absolute;
+            left: 50%;
+            top: 50%;
+            -webkit-transform: translate(-50%, -50%);
+                -ms-transform: translate(-50%, -50%);
+                    transform: translate(-50%, -50%);
+          }
+          
+          .notfound {
+            max-width: 560px;
+            width: 100%;
+            padding-left: 160px;
+            line-height: 1.1;
+          }
+          
+          .notfound .notfound-404 {
+            position: absolute;
+            left: 0;
+            top: 0;
+            display: inline-block;
+            width: 140px;
+            height: 140px;
+            background-image: url('./bb-themes/boxbilling/assets/images/logo.png');
+            background-size: cover;
+          }
+          
+          .notfound .notfound-404:before {
+            content: '';
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            -webkit-transform: scale(2.4);
+                -ms-transform: scale(2.4);
+                    transform: scale(2.4);
+            border-radius: 50%;
+            background-color: #f2f5f8;
+            z-index: -1;
+          }
+          
+          .notfound h1 {
+            font-family: 'Nunito', sans-serif;
+            font-size: 65px;
+            font-weight: 700;
+            margin-top: 0px;
+            margin-bottom: 10px;
+            color: #151723;
+            text-transform: uppercase;
+          }
+          
+          .notfound h2 {
+            font-family: 'Nunito', sans-serif;
+            font-size: 21px;
+            font-weight: 400;
+            margin: 0;
+            text-transform: uppercase;
+            color: #151723;
+          }
+          
+          .notfound p {
+            font-family: 'Nunito', sans-serif;
+            color: #999fa5;
+            font-weight: 400;
+          }
+          
+          .notfound a {
+            font-family: 'Nunito', sans-serif;
+            display: inline-block;
+            font-weight: 700;
+            border-radius: 40px;
+            text-decoration: none;
+            color: #388dbc;
+          }
+          
+          @media only screen and (max-width: 767px) {
+            .notfound .notfound-404 {
+              width: 110px;
+              height: 110px;
+            }
+            .notfound {
+              padding-left: 15px;
+              padding-right: 15px;
+              padding-top: 110px;
+            }
+          }
+          
+        </style>
+    </head>
+    <body>
+
+    <div id=\"notfound\">
+        <div class=\"notfound\">
+            <div class=\"notfound-404\"></div>
+            <h1>Error</h1>";
     $page = str_replace(PHP_EOL, "", $page);
     print $page;
     if($e->getCode()) {
-        print sprintf('<p>Code: <em>%s</em></p>', $e->getCode());
+        print sprintf('<h2>Error code: <em>%s</em></h1>', $e->getCode());
     }
     print sprintf('<p>%s</p>', $e->getMessage());
     print sprintf('<p><a href="http://docs.boxbilling.com/en/latest/search.html?q=%s&check_keywords=yes&area=default" target="_blank">Look for detailed error explanation</a></p>', urlencode($e->getMessage()));
@@ -70,13 +192,17 @@ function handler_exception($e)
         print sprintf('<p>Line: "%s"</p>', $e->getLine());
         print sprintf('Trace: <pre>%s</pre>', $e->getTraceAsString());
     }
+    print("<center><hr><p>Powered by <a href=//www.boxbilling.com/>BoxBilling</a></p></center>
+    </body>
+    
+    </html>");
 }
 
 set_exception_handler("handler_exception");
 set_error_handler('handler_error');
 
-// multisite support. Load new config depending on current host
-// if run from cli first param must be hostname
+// Multisite support. Load new configuration depending on the current hostname
+// If being run from CLI, first parameter must be the hostname
 $configPath = BB_PATH_ROOT.'/bb-config.php';
 if((isset($_SERVER['HTTP_HOST']) && $_SERVER['HTTP_HOST']) || (php_sapi_name() == 'cli' && isset($argv[1]) ) ) {
     if(php_sapi_name() == 'cli') {
@@ -91,17 +217,17 @@ if((isset($_SERVER['HTTP_HOST']) && $_SERVER['HTTP_HOST']) || (php_sapi_name() =
     }
 }
 
-// check if config is available
+// Try to check if configuration is available
 if(!file_exists($configPath) || 0 == filesize( $configPath )) {
     
-    //try create empty config file
+    // Try to create an empty configuration file
     @file_put_contents($configPath, '');
     
     $base_url = "http://".$_SERVER['HTTP_HOST'];
     $base_url .= preg_replace('@/+$@','',dirname($_SERVER['SCRIPT_NAME'])).'/';
     $url = $base_url . 'install/index.php';
     $configFile = pathinfo($configPath, PATHINFO_BASENAME);
-    $msg = sprintf("There doesn't seem to be a <em>$configFile</em> file or bb-config.php file does not contain required configuration parameters. I need this before we can get started. Need more help? <a target='_blank' href='http://docs.boxbilling.com/en/latest/reference/installation.html'>We got it</a>. You can create a <em>$configFile</em> file through a web interface, but this doesn't work for all server setups. The safest way is to manually create the file.</p><p><a href='%s' class='button'>Continue with BoxBilling installation</a>", $url);
+    $msg = sprintf("The <em>$configFile</em> path seems to be invalid. You may have not generated the configuration file yet, or the configuration file may not contain the required configuration parameters. BoxBilling needs to have a valid configuration file present in order to function properly. Need some help with the installation? <a target='_blank' href='http://docs.boxbilling.com/en/latest/reference/installation.html'>We got it</a>. You can create the configuration file using the interactive installer, or manually create the configuration file.</p><p>If it's your first time setting up BoxBilling, you can <a href='%s' class='button'>continue with the web-based interactive BoxBilling installation</a>.", $url);
     throw new Exception($msg, 101);
 }
 

--- a/src/bb-load.php
+++ b/src/bb-load.php
@@ -78,12 +78,12 @@ function handler_exception($e)
             margin: 0;
           }
           
-          #notfound {
+          #error {
             position: relative;
             height: 100vh;
           }
           
-          #notfound .notfound {
+          #error .error {
             position: absolute;
             left: 50%;
             top: 50%;
@@ -92,14 +92,14 @@ function handler_exception($e)
                     transform: translate(-50%, -50%);
           }
           
-          .notfound {
+          .error {
             max-width: 560px;
             width: 100%;
             padding-left: 160px;
             line-height: 1.1;
           }
           
-          .notfound .notfound-404 {
+          .error .error-container {
             position: absolute;
             left: 0;
             top: 0;
@@ -110,7 +110,7 @@ function handler_exception($e)
             background-size: cover;
           }
           
-          .notfound .notfound-404:before {
+          .error .error-container:before {
             content: '';
             position: absolute;
             width: 100%;
@@ -123,7 +123,7 @@ function handler_exception($e)
             z-index: -1;
           }
           
-          .notfound h1 {
+          .error h1 {
             font-family: 'Nunito', sans-serif;
             font-size: 65px;
             font-weight: 700;
@@ -133,7 +133,7 @@ function handler_exception($e)
             text-transform: uppercase;
           }
           
-          .notfound h2 {
+          .error h2 {
             font-family: 'Nunito', sans-serif;
             font-size: 21px;
             font-weight: 400;
@@ -142,13 +142,13 @@ function handler_exception($e)
             color: #151723;
           }
           
-          .notfound p {
+          .error p {
             font-family: 'Nunito', sans-serif;
             color: #999fa5;
             font-weight: 400;
           }
           
-          .notfound a {
+          .error a {
             font-family: 'Nunito', sans-serif;
             display: inline-block;
             font-weight: 700;
@@ -158,11 +158,11 @@ function handler_exception($e)
           }
           
           @media only screen and (max-width: 767px) {
-            .notfound .notfound-404 {
+            .error .error-container {
               width: 110px;
               height: 110px;
             }
-            .notfound {
+            .error {
               padding-left: 15px;
               padding-right: 15px;
               padding-top: 110px;
@@ -173,9 +173,9 @@ function handler_exception($e)
     </head>
     <body>
 
-    <div id=\"notfound\">
-        <div class=\"notfound\">
-            <div class=\"notfound-404\"></div>
+    <div id=\"error\">
+        <div class=\"error\">
+            <div class=\"error-container\"></div>
             <h1>Error</h1>";
     $page = str_replace(PHP_EOL, "", $page);
     print $page;


### PR DESCRIPTION
This pull request implements a whole new approach to our error messages. With the new layout for errors, BoxBilling looks even better, and refreshed.

Also, the loader now checks if the /install directory still exists, even after the installation was completed, and doesn't load the page if so. That's a new security measure.

Before (currently in use):
![Old page](https://i.imgur.com/4SivmRF.png)

Here is an example of the new error page:
![Error page](https://i.imgur.com/NctvXjG.png)

For now, the only thing is that I couldn't find a better resolution of the logo, so I had to use one with a lower resolution. When I get the chance to find one with a better resolution, I'll update it to display the logo in full resolution.