### PR TITLE
SEF-URLs & .htaccess

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -1,6 +1,5 @@
 # Read documentation http://docs.boxbilling.com/ for more information
-# Rename this file to .htaccess in order to work
-# If you are receiving "Internal Server Error" message - make sure mod_rewrite is enabled in apache
+# If you are receiving "Internal Server Error" message, make sure mod_rewrite is enabled in apache
 
 Options -Indexes
 Options +FollowSymLinks
@@ -24,7 +23,7 @@ RewriteRule .* index.php [F]
 #
 ## End - Rewrite rules to block out some common exploits.
 
-### re-direct to www
+### Redirect to www
 #RewriteCond %{HTTP_HOST} ^yourdomain.com
 #RewriteRule (.*) http://www.yourdomain.com/$1 [R=301,L]
 

--- a/src/bb-config-sample.php
+++ b/src/bb-config-sample.php
@@ -31,7 +31,7 @@ return array(
      * Configure .htaccess file before enabling this feature
      * Set to TRUE if using nginx
      */
-    'sef_urls'  => false,
+    'sef_urls'  => true,
 
     /**
      * Application timezone


### PR DESCRIPTION
Renamed "htaccess.txt" to ".htaccess", the users shouldn't need to rename it after installation, we can directly set it's name to .htaccess.

Also, SEO-friendly URLs can be enabled by default, I guess.
They look better, easier to share and navigate to.

So from now on, _"yourdomain.com/index.php?_url=abc"_ will become to _"yourdomain.com/abc"_ by default, while also keeping support backwards for the first one.