### PR TITLE
#780, PHP CLI & cron related things

### DIFF
--- a/src/bb-cron.php
+++ b/src/bb-cron.php
@@ -13,10 +13,21 @@
 
 require_once dirname(__FILE__) . '/bb-load.php';
 $di = include dirname(__FILE__) . '/bb-di.php';
+
 $di['translate']();
 
-$interval = isset($argv[1]) ? $argv[1] : null;
-$service = $di['mod_service']('cron');
-$service->runCrons($interval);
-
-unset($service, $interval, $di);
+try {
+    $interval = isset($argv[1]) ? $argv[1] : null;
+    $service = $di['mod_service']('cron');
+    $service->runCrons($interval);
+ } catch (Exception $exception) {
+    throw new Expection($exception);
+ } finally {
+    if (php_sapi_name() == 'cli') {
+        print ("\e[32mSuccessfully ran the cron jobs.\e[0m");
+    } else {
+        $login_url = $di['url']->link('bb-admin');
+        unset($service, $interval, $di);
+        header("Location: $login_url");
+    }
+ }

--- a/src/bb-load.php
+++ b/src/bb-load.php
@@ -19,11 +19,16 @@ define('BB_PATH_MODS',      BB_PATH_ROOT . '/bb-modules');
 define('BB_PATH_LANGS',     BB_PATH_ROOT . '/bb-locale');
 define('BB_PATH_UPLOADS',   BB_PATH_ROOT . '/bb-uploads');
 define('BB_PATH_DATA',   BB_PATH_ROOT . '/bb-data');
+define('isCLI', php_sapi_name() == 'cli');
 
-function handler_error($number, $message, $file, $line)
+function handler_error(int $number, string $message, string $file, int $line)
 {
     if (E_RECOVERABLE_ERROR===$number) {
+      if (isCLI) {
+        echo "Error #[$number] occurred in [$file] at line [$line]: [$message]";
+      } else {
         handler_exception(new ErrorException($message, $number, 0, $file, $line));
+      }
     } else {
         error_log($number." ".$message." ".$file." ".$line);
     }
@@ -33,6 +38,9 @@ function handler_error($number, $message, $file, $line)
 // Removed Exception type. Some errors are thrown as exceptions causing fatal errors.
 function handler_exception($e)
 {
+  if (isCLI) {
+    echo "Error #[". $e->getLine() ."] occurred in [". $e->getFile() ."] at line [". $e->getLine() ."]: [". $e->getMessage() ."]";
+  } else {
     if(APPLICATION_ENV == 'testing') {
         print $e->getMessage() . PHP_EOL;
         return ;
@@ -168,6 +176,14 @@ function handler_exception($e)
               padding-top: 110px;
             }
           }
+
+          code {
+            font-family: Consolas,'courier new';
+            color: crimson;
+            background-color: #f1f1f1;
+            padding: 2px;
+            font-size: 90%;
+          }
           
         </style>
     </head>
@@ -183,19 +199,20 @@ function handler_exception($e)
         print sprintf('<h2>Error code: <em>%s</em></h1>', $e->getCode());
     }
     print sprintf('<p>%s</p>', $e->getMessage());
-    print sprintf('<center><p><a href="http://docs.boxbilling.com/en/latest/search.html?q=%s&check_keywords=yes&area=default" target="_blank">Look for detailed error explanation</a></p></center>', urlencode($e->getMessage()));
-
+    
     if(defined('BB_DEBUG') && BB_DEBUG) {
-        print sprintf('<em>%s</em>', 'Set BB_DEBUG to FALSE, to hide the message below');
+        print sprintf('<hr><center><small><p><b>%s</b></p></small></center>', 'Set BB_DEBUG to FALSE, to hide the message below');
         print sprintf('<p>Class: "%s"</p>', get_class($e));
         print sprintf('<p>File: "%s"</p>', $e->getFile());
         print sprintf('<p>Line: "%s"</p>', $e->getLine());
-        print sprintf('Trace: <pre>%s</pre>', $e->getTraceAsString());
+        print sprintf('Trace: <code>%s</code>', $e->getTraceAsString());
     }
+    print sprintf('<center><p><a href="http://docs.boxbilling.com/en/latest/search.html?q=%s&check_keywords=yes&area=default" target="_blank">Look for detailed error explanation</a></p></center>', urlencode($e->getMessage()));
     print("<center><hr><p>Powered by <a href=//www.boxbilling.com/>BoxBilling</a></p></center>
     </body>
     
     </html>");
+  }
 }
 
 set_exception_handler("handler_exception");


### PR DESCRIPTION
Closes #780. As you know, BoxBilling is designed to have cron jobs, and we run them from terminal. When something unexpected occurs, the error directly appears in the terminal.

When an error was catched in terminal, it used to look like this:
![Error message](https://i.imgur.com/fGNl7Ag.png)

But now, it just looks like this:
![New one](https://i.imgur.com/QuxKHgR.png)

Also, when the cron job was successfully finished, it now prints this (instead of directly killing the process but not printing any kind of confirmation message):
![Success](https://i.imgur.com/aDzeEwP.png)

When the cron job was executed from the browser, it now redirects the user to the admin panel, before, it used to display a completely blank white page instead.