### PR TITLE
Loader and error handler enhancements

### DIFF
--- a/src/bb-load.php
+++ b/src/bb-load.php
@@ -39,7 +39,7 @@ function handler_error(int $number, string $message, string $file, int $line)
 function handler_exception($e)
 {
   if (isCLI) {
-    echo "Error #[". $e->getLine() ."] occurred in [". $e->getFile() ."] at line [". $e->getLine() ."]: [". $e->getMessage() ."]";
+    echo "Error #[". $e->getLine() ."] occurred in [". $e->getFile() ."] at line [". $e->getLine() ."]: [". trim(strip_tags($e->getMessage())) ."]";
   } else {
     if(APPLICATION_ENV == 'testing') {
         print $e->getMessage() . PHP_EOL;
@@ -250,7 +250,7 @@ if(!file_exists($configPath) || 0 == filesize($configPath)) {
     $base_url .= preg_replace('@/+$@','',dirname($_SERVER['SCRIPT_NAME']));
     $url = $base_url . '/install/index.php';
     $configFile = pathinfo($configPath, PATHINFO_BASENAME);
-    $msg = sprintf("The <em>$configFile</em> path seems to be invalid. You may have not generated the configuration file yet, or the configuration file may not contain the required configuration parameters. BoxBilling needs to have a valid configuration file present in order to function properly.</p><p>Need some help with the installation? <a target='_blank' href='http://docs.boxbilling.com/en/latest/reference/installation.html'>We got it</a>. You can create the configuration file using the interactive installer, or manually create the configuration file.</p><p>If it's your first time setting up BoxBilling, you can <a href='%s' class='button'>continue with the web-based interactive BoxBilling installation</a>.", $url);
+    $msg = sprintf("The <em>$configFile</em> path seems to be invalid. You may have not generated the configuration file yet, or the configuration file may not contain the required configuration parameters. BoxBilling needs to have a valid configuration file present in order to function properly.</p> <p>Need some help with the installation? <a target='_blank' href='http://docs.boxbilling.com/en/latest/reference/installation.html'>We got it</a>. You can create the configuration file using the interactive installer, or manually create the configuration file.</p> <p>If it's your first time setting up BoxBilling, you can <a href='%s' class='button'>continue with the web-based interactive BoxBilling installation</a>.", $url);
     throw new Exception($msg, 101);
 }
 


### PR DESCRIPTION
The terminal part of the error handler can now sanitize the error message and remove all HTML stuff.

Before:
![Before](https://i.imgur.com/0vQUg6v.png)

After:
![After](https://i.imgur.com/gVj7hw1.png)