### PR TITLE
Domain check when "whois" is off

### DIFF
--- a/src/bb-library/Registrar/Adapter/Custom.php
+++ b/src/bb-library/Registrar/Adapter/Custom.php
@@ -47,8 +47,12 @@ class Registrar_Adapter_Custom extends Registrar_AdapterAbstract
         if($this->config['use_whois']) {
             $w = new Whois($domain->getName());
             return $w->isAvailable();
+        } else {
+            $domain = $domain->getName();
+            if ( gethostbyname($domain) == $domain ) :
+                return true;
+            endif;
         }
-        return true;
     }
 
     public function modifyNs(Registrar_Domain $domain)


### PR DESCRIPTION
When "whois" is off in custom domain registrar it will check domain availability using DNS, I know its not reliable but returning every domain as available is redundant.