### PR TITLE
Fix missing tag.

### DIFF
--- a/src/bb-themes/bootstrap/html/mod_invoice_thankyou.phtml
+++ b/src/bb-themes/bootstrap/html/mod_invoice_thankyou.phtml
@@ -17,7 +17,7 @@
 	<div class="alert alert-success text-center">
 		<h2>{% trans 'Payment for invoice received' %}</h2>
 		<p>{% trans 'Your payment is being processed right now. This takes about 5 minutes to complete' %}</p>
-		<p>{% 'You will be automatically redirected to invoice page after 5 minutes.' %}</p>
+		<p>{% trans 'You will be automatically redirected to invoice page after 5 minutes.' %}</p>
 	</div>
 {% endblock %}
 


### PR DESCRIPTION
Fix missing tag of bootstrap theme.

`/invoice/thank-you/<invoice id>` would throw exception: `A block must start with a tag name.` because a `trans` tag is missing in `src/bb-themes/bootstrap/html/mod_invoice_thankyou.phtml`.
