### PR TITLE
[INSTALL] Added a PHP version cutoff

### DIFF
--- a/src/bb-library/Box/Requirements.php
+++ b/src/bb-library/Box/Requirements.php
@@ -42,6 +42,7 @@ class Box_Requirements implements \Box\InjectionAwareInterface
                  ),
                 'version'       =>  PHP_VERSION,
                 'min_version'   =>  '7.2',
+                'cutoff_version' => '8.0',
                 'safe_mode'     =>  ini_get('safe_mode'),
             ),
             'writable_folders' => array(
@@ -107,7 +108,13 @@ class Box_Requirements implements \Box\InjectionAwareInterface
     {
         $current = $this->_options['php']['version'];
         $required = $this->_options['php']['min_version'];
-        return version_compare($current, $required, '>=');
+        $cutoff = $this->_options['php']['cutoff_version'];
+		
+        if(version_compare($current, $cutoff, '>=') <= 0 && version_compare($current, $required, '>=') > 0){
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public function isBoxVersionOk()

--- a/src/install/assets/install.phtml
+++ b/src/install/assets/install.phtml
@@ -94,7 +94,7 @@
                                     <tr>
                                         <td>PHP version</td>
                                         <td><strong class="{{ php_ver_ok ? 'green' : 'red'}}">{{ php_ver }}</strong></td>
-                                        <td>{% if not php_ver_ok %}Required PHP version >{{ php_ver_req }}{% endif %}</td>
+                                        <td>{% if not php_ver_ok %}Required PHP version is greater than {{ php_ver_req }} and less than {{ php_ver_cutoff }}{% endif %}</td>
                                     </tr>
 
                                     <tr>

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -155,6 +155,7 @@ final class Box_Installer
                     'box_ver_ok' => $se->isBoxVersionOk(),
                     'php_ver' => $options['php']['version'],
                     'php_ver_req' => $options['php']['min_version'],
+                    'php_ver_cutoff' => $options['php']['cutoff_version'],
                     'php_safe_mode' => $options['php']['safe_mode'],
                     'php_ver_ok' => $se->isPhpVersionOk(),
                     'extensions' => $se->extensions(),


### PR DESCRIPTION
Adds a check to ensure the PHP version isn't too high in the form of a "cutoff". I.E. anything less than the cutoff is acceptable. I did this since PHP 7.X will still be receiving incremental updates so hard coding a maximum 7.X version doesn't make sense to me.

PHP 8:
![Too high](https://user-images.githubusercontent.com/17304943/127780832-b68b807d-b44f-46bf-92d7-6220f85ffc26.PNG)

Less than, but still above 7.2
![right version](https://user-images.githubusercontent.com/17304943/127780835-3f99ea12-835e-4171-99f6-e2e8d2f44af6.PNG)