### PR TITLE
Slightly improved API rate limiter

### DIFF
--- a/src/bb-config-sample.php
+++ b/src/bb-config-sample.php
@@ -109,5 +109,22 @@ return array(
 
         // How many requests allowed per time span
         'rate_limit'        =>  1000,
+
+        /**
+         * Note about rate limiting login attempts:
+         * When the limit is reach, a simple 2 second delay is added to the request. 
+         * This makes brute forcing a password basically useless while not outright blocking legitimate traffic.
+         * When calculating, ensure the rate limited traffic can still make enough requests to stay rate limited
+         * Ex: One request every 2 seconds is more than 20 times in 1 minute, so the IP will remain throttled
+         */
+
+        // Throttling delay
+        'throttle_delay'         =>  2,
+
+        // Time span login for limit in seconds
+        'rate_span_login'         =>  60,
+
+        // How many login requests allowed per time span
+        'rate_limit_login'        =>  20,
     ),
 );

--- a/src/bb-library/Box/Request.php
+++ b/src/bb-library/Box/Request.php
@@ -249,10 +249,11 @@ class Box_Request implements \Box\InjectionAwareInterface
 
     /**
      * Gets most possible client IPv4 Address. This method search in $_SERVER[‘REMOTE_ADDR’] and optionally in $_SERVER[‘HTTP_X_FORWARDED_FOR’]
-     * @param bool $trustForwardedHeader - should we trust forwarded header?
+     * @param bool $trustForwardedHeader - No by default because this can be changed to anything extremely easy, making it unreliable for tracking and adding a potential source for external data to be executed.
+     * Please see: https://stackoverflow.com/questions/3003145/how-to-get-the-client-ip-address-in-php
      * return string
      */
-    public function getClientAddress($trustForwardedHeader = true)
+    public function getClientAddress($trustForwardedHeader = false)
     {
         $address = null;
         if($trustForwardedHeader) {

--- a/src/bb-modules/Api/Controller/Client.php
+++ b/src/bb-modules/Api/Controller/Client.php
@@ -95,16 +95,24 @@ class Client implements InjectionAwareInterface
         }
     }
 
-    private function checkRateLimit()
+    private function checkRateLimit($method=null)
     {
-        $rate_span  = $this->_api_config['rate_span'];
-        $rate_limit = $this->_api_config['rate_limit'];
+        $isLoginMethod = false;
+        if($method == 'staff_login' || $method == 'client_login'){
+            $rate_span  = $this->_api_config['rate_span_login'];
+            $rate_limit = $this->_api_config['rate_limit_login'];
+            $isLoginMethod = true;
+        } else {
+            $rate_span  = $this->_api_config['rate_span'];
+            $rate_limit = $this->_api_config['rate_limit'];
+        }
+
         $service = $this->di['mod_service']('api');
-        $requests = $service->getRequestCount(time() - $rate_span, $this->_getIp());
+        $requests = $service->getRequestCount(time() - $rate_span, $this->_getIp(), $isLoginMethod);
         $requests_left = $rate_limit - $requests;
         $this->_requests_left = $requests_left;
         if ($requests_left < 0) {
-            throw new \Box_Exception('Request limit reached', null, 1003);
+            sleep($this->_api_config['throttle_delay']);
         }
         return true;
     }
@@ -151,7 +159,7 @@ class Client implements InjectionAwareInterface
 
         $service = $this->di['mod_service']('api');
         $service->logRequest();
-        $this->checkRateLimit();
+        $this->checkRateLimit($method);
         $this->checkHttpReferer();
         $this->isRoleAllowed($role);
 

--- a/src/bb-modules/Api/Service.php
+++ b/src/bb-modules/Api/Service.php
@@ -54,7 +54,7 @@ class Service implements \Box\InjectionAwareInterface
      * @param string|null $ip
      * @return int
      */
-    public function getRequestCount($since, $ip = null)
+    public function getRequestCount($since, $ip = null, $isLoginMethod = false)
     {
         if (!is_numeric($since)){
             $since = strtotime($since);
@@ -63,11 +63,19 @@ class Service implements \Box\InjectionAwareInterface
         $values = array(
             'since' =>  $sinceIso,
         );
+        if($isLoginMethod){
+        $sql="
+        SELECT COUNT(id) as cclogin
+        FROM api_request
+        WHERE created_at > :since
+        ";
+        } else {
         $sql="
         SELECT COUNT(id) as cc
         FROM api_request
         WHERE created_at > :since
         ";
+        }
 
         if(null != $ip) {
             $sql .= " AND ip = :ip";

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -383,6 +383,9 @@ final class Box_Installer
                 'allowed_ips' => [],
                 'rate_span' => 60 * 60,
                 'rate_limit' => 1000,
+                'throttle_delay' => 2,
+                'rate_span_login' =>  60,
+                'rate_limit_login' = 20,
             ],
         ];
         $output = '<?php ' . PHP_EOL;

--- a/tests/bb-library/Box/Box_RequestTest.php
+++ b/tests/bb-library/Box/Box_RequestTest.php
@@ -293,7 +293,7 @@ class Box_RequestTest extends PHPUnit\Framework\TestCase
             )
         );
 
-        $this->assertEquals('123.123.123.120', $request->getClientAddress());
+        $this->assertEquals('123.123.123.120', $request->getClientAddress(true));
         $this->assertEquals('123.123.123.121', $request->getClientAddress(true));
     }
 
@@ -312,7 +312,7 @@ class Box_RequestTest extends PHPUnit\Framework\TestCase
             )
         );
 
-        $this->assertEquals('123.123.123.1', $request->getClientAddress(false));
+        $this->assertEquals('123.123.123.1', $request->getClientAddress());
         $this->assertEquals('123.123.123.2', $request->getClientAddress(false));
     }
 


### PR DESCRIPTION
My fix for issue https://github.com/boxbilling/boxbilling/issues/842
These are some somewhat minor changes for improved security and performance when the server is experiencing a brute force attack on the login functions.

Added 3 new settings specific to rate limiting login APIs. These are their default values.
```
'throttle_delay' => 2,
'rate_span_login' =>  60,
'rate_limit_login' = 20,
```
When the number of allowed attempts (`rate_limit_login`) is reached within the specified time length (`rate_span_login`) we then timeout for the specified time length (`throttle_delay`). This hugely reduces the effectiveness of any brute force attack on the login API while only acting as a minor inconvenience to the end user.

This timeout has is also being used now for any other API call, so we can simply throttle rather than stop the client from logging in.

Modified the `getClientAddress()` function to no longer respect and use HTTP's `x-forwarded-for`. While it can be useful if the end user is behind a proxy, it raises more potential security risk than it's worth. Anybody can easily change this header to be anything they want. This makes it basically useless for tracking "clients", and there is also no guarantee that this header will even be an IP address and not potentially a code that is intended to exploit the system. 

Up for debate:
Now that we throttle and slow down requests when the limit has been reached, does it make sense to lower the limit for other non-login related API functions?