### PR TITLE
Create issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,46 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for choosing BoxBilling, please fill out the information below to get the best assistance we can provide
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "Please describe the problem"
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: BoxBilling Version
+      description: What version of BoxBilling are you running?
+      options:
+        - v4.21
+        - v4.22-beta.1
+        - Current Master Branch
+    validations:
+      required: true
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What version of PHP are you running?
+      description: We only support between version 7.2 and 7.4, any other version will cause issues and not work.
+      multiple: false
+      options:
+        - 7.2x
+        - 7.3x
+        - 7.4x
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional Notes
+      description: Please provide any additional notes. Important things to know include what theme you are using and software your server is running
+      placeholder: This doesn't show up so idonno what it is
+      value: "Additional notes"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
Create an issue report template. Helpful to ensure we get good bug reports that include basic info needed. Also results in easy to view tickets. We can also create additional template for feature requests and other things that people may use the issues section for
![image](https://user-images.githubusercontent.com/17304943/128219393-a8fdf53c-4b2b-4aed-b5ad-9e30b74a22d4.png)
 
![image](https://user-images.githubusercontent.com/17304943/128219429-b0ea902e-b5cb-4cf1-baed-38e5a30a1fd8.png)
