### PR TITLE
Replaces boxbilling.com links with the github page

### DIFF
--- a/src/bb-load.php
+++ b/src/bb-load.php
@@ -208,7 +208,7 @@ function handler_exception($e)
         print sprintf('Trace: <code>%s</code>', $e->getTraceAsString());
     }
     print sprintf('<center><p><a href="http://docs.boxbilling.com/en/latest/search.html?q=%s&check_keywords=yes&area=default" target="_blank">Look for detailed error explanation</a></p></center>', urlencode($e->getMessage()));
-    print("<center><hr><p>Powered by <a href=//www.boxbilling.com/>BoxBilling</a></p></center>
+    print("<center><hr><p>Powered by <a href=//https://github.com/boxbilling/boxbilling/>BoxBilling</a></p></center>
     </body>
     
     </html>");

--- a/src/bb-themes/admin_default/html/mod_extension_index.phtml
+++ b/src/bb-themes/admin_default/html/mod_extension_index.phtml
@@ -118,7 +118,7 @@
 
             <div class="body list arrowGreen">
                 <ul>
-                    <li>Download latest BoxBilling from <a href="http://www.boxbilling.com/download" target="_blank">www.boxbilling.com</a></li>
+                    <li>Download latest BoxBilling from <a href="https://github.com/boxbilling/boxbilling/releases" target="_blank">Our Github</a></li>
                     <li>Extract files at your computer</li>
                     <li>Upload (overwrite) extracted files via FTP to <strong>{{ constant('BB_PATH_ROOT') }}</strong></li>
                     <li>When upload is complete, execute <a href="{{constant('BB_URL')}}bb-update.php" target="_blank">{{constant('BB_URL')}}bb-update.php</a> in your browser</li>

--- a/src/bb-themes/bootstrap/html/layout_default.phtml
+++ b/src/bb-themes/bootstrap/html/layout_default.phtml
@@ -237,7 +237,7 @@
 							{% endif %}
 						{% endfor %}
 						{% if guest.extension_is_on({"mod":'branding'}) or settings.footer_branding_enabled %}
-							<li><a href="http://www.boxbilling.com" title="Billing Software" target="_blank">{% trans 'Powered by BoxBilling' %}</a></li>
+							<li><a href="https://github.com/boxbilling/boxbilling" title="Billing Software" target="_blank">{% trans 'Powered by the BoxBilling Community' %}</a></li>
 						{% endif %}
                     </ul>
 					

--- a/src/bb-themes/boxbilling/html/mod_index_dashboard.phtml
+++ b/src/bb-themes/boxbilling/html/mod_index_dashboard.phtml
@@ -67,7 +67,7 @@
     {% if guest.extension_is_on({"mod":"branding"}) %}
     <div class="grid_6 omega">
         <div class="box">
-            <h2 class="big-dark-icon i-boxbilling"><a href="http://www.boxbilling.com">{% trans 'Invoicing Software' %}</a></h2>
+            <h2 class="big-dark-icon i-boxbilling"><a href="https://github.com/boxbilling/boxbilling">{% trans 'Invoicing Software' %}</a></h2>
             <div class="block">
                 <p>{% trans 'Powered by BoxBilling invoicing software' %}</p>
             </div>

--- a/src/bb-themes/huraga/html/layout_default.phtml
+++ b/src/bb-themes/huraga/html/layout_default.phtml
@@ -249,7 +249,7 @@
 
         {% if guest.extension_is_on({"mod":'branding'}) %}
         <li>
-            <a href="http://www.boxbilling.com" title="Billing Software" target="_blank">{% trans 'Powered by BoxBilling' %}</a>
+            <a href="https://github.com/boxbilling/boxbilling" title="Billing Software" target="_blank">{% trans 'Powered by the BoxBilling Community' %}</a>
         </li>
         {% endif %}
     </ul>


### PR DESCRIPTION
Replaced links to boxbilling.com to the github since that will always be the most up-to-date source. If we get a good website online and updated, we can switch back to it then. 

Also, slightly reworded "Powered by BoxBilling" to instead be "Powered by the BoxBilling Community", as we are now community driven this seems more fitting.

Related: We may want to consider a new spot for extensions as extensions.boxbilling.com is completely down. 
Maybe we can update https://github.com/boxbilling/extensions/tree/master to have a full readme and use releases to release non developmental extensions. Not a priority right now, I think extensions are more work than we need for the time being