### PR TITLE
Use random_bytes instead of uniqid since it actually generates crypto…

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,10 +7,16 @@ currently being supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 4.20.x   | :white_check_mark: |
+| 4.22.x   | :white_check_mark: |
 
-## Reporting Bugs
+## Reporting Vulnerabilities 
+To report a vulnerability, it's please make a submission on [huntr.dev](https://huntr.dev/bounties/disclose). Enter https://github.com/boxbilling/boxbilling as the repository and then go from there. Their website should provide you a good idea for the requirements of a good vulnerability report.
+It's important to make the submission there as it keeps the vulnerability private which helps ensure it can't be exploited while a patch is in the works. If you have a suggestion that is related to security, then [creating an issue](https://github.com/boxbilling/boxbilling/issues/new/choose) on github is a suitable place.
 
+Usually a good report should include where the file is, how the vulnerability could be explointed, the potential ramifications of the vulnerability, a proof of concept exploit, and if possible insight into a solution. A proper vulnerability report is awarded with a cash reward, if you provide a patch there is usually a reward with that as well.  
+
+## Not a Vulnerability?
+**Reporting bugs**
 This section guides you through submitting a bug report for BoxBilling. Following these guidelines helps maintainers and the community understand your report 📝, reproduce the behavior 💻 💻, and find related reports 🔎.
 
 Before creating bug reports, please check this list as you might find out that you don't need to create one. When you are creating a bug report, please include as many details as possible.

--- a/src/bb-modules/Support/Service.php
+++ b/src/bb-modules/Support/Service.php
@@ -816,7 +816,7 @@ class Service implements \Box\InjectionAwareInterface
         }
 
         $ticket               = $this->di['db']->dispense('SupportPTicket');
-        $ticket->hash         = sha1(uniqid());
+        $ticket->hash         = sha1(random_bytes(13));
         $ticket->author_name  = $data['name'];
         $ticket->author_email = $data['email'];
         $ticket->subject      = $subject;
@@ -1206,7 +1206,7 @@ class Service implements \Box\InjectionAwareInterface
         $this->di['events_manager']->fire(array('event' => 'onBeforeAdminPublicTicketOpen', 'params' => $data));
 
         $ticket               = $this->di['db']->dispense('SupportPTicket');
-        $ticket->hash         = sha1(uniqid());
+        $ticket->hash         = sha1(random_bytes(13));
         $ticket->author_name  = $data['name'];
         $ticket->author_email = $data['email'];
         $ticket->subject      = $data['subject'];


### PR DESCRIPTION
Someone on huntr.dev didn't like how we used a cryptographically flawed function to generate the hash and marked it a vulnerability. With PHP 7+ we get the wonderful [random_bytes](https://www.php.net/manual/en/function.random-bytes.php) functionality which is actually cryptographically secure, so we will just use it instead. Using a length of 13 just because that's how long the `uniqid()` call would have been.
**Weakness:**
`CWE-327`
**Severity:**
`Medium (5.9)`

Edit: after this the only known vulnerability in BB is the potential for SQL injection in the installer, which is fairly minor since it's deleted after installation. I do plan to submit a patch for it though