### PR TITLE
Clean the PHP log file when it gets large

### DIFF
--- a/src/bb-modules/Cron/Service.php
+++ b/src/bb-modules/Cron/Service.php
@@ -51,6 +51,16 @@ class Service
         $api = $this->di['api_system'];
         $this->di['logger']->info('- Started executing cron');
 
+        $MaxLogSizeMB = 2;
+        $LogPath = BB_PATH_LOG . '/php_error.log';
+
+        if(filesize($LogPath) > $MaxLogSizeMB * 1000000 ){
+            $this->di['logger']->info('- Cleaning large PHP log');
+            if(!unlink($LogPath)){
+                $this->di['logger']->info('- Failed to clean large PHP log');
+            }
+        }
+        
         //@core tasks
         $this->_exec($api, 'hook_batch_connect');
         $this->di['events_manager']->fire(array('event'=>'onBeforeAdminCronRun'));


### PR DESCRIPTION
This way people who are running BB won't potentially end up with an extremely large PHP log.
It would take an extremely long time to teach 2MB unless there's a major problem, so I don't think we're at risk of loosing important log information to this, or ever even reaching it.
Still, I consider this to be a QOL change