### PR TITLE
Removed links to the dead forum of ours

### DIFF
--- a/src/bb-themes/admin_default/html/partial_footer.phtml
+++ b/src/bb-themes/admin_default/html/partial_footer.phtml
@@ -13,10 +13,6 @@
                             <td class="noborder"><a href="http://docs.boxbilling.com/" title="" target="_blank">{% trans 'Help' %}</a></td>
                         </tr>
                         <tr>
-                            <td><i class="dark-sprite-icon sprite-speech2" /></td>
-                            <td class="noborder"><a href="http://www.boxbilling.com/forum" title="" target="_blank">{% trans 'Forum' %}</a></td>
-                        </tr>
-                        <tr>
                             <td><i class="dark-sprite-icon sprite-pacman" /></td>
                             <td class="noborder"><a href="https://github.com/boxbilling/boxbilling/issues" title="" target="_blank">{% trans 'Report bug' %}</a></td>
                         </tr>

--- a/src/install/assets/layout.phtml
+++ b/src/install/assets/layout.phtml
@@ -13,8 +13,8 @@
     <div class="logo"><a href="{{ constant('BB_URL_INSTALL') }}" title="BoxBilling"><img src="../bb-themes/boxbilling/assets/images/logo.png" alt="" style="max-height: 50px"/></a></div>
     <div class="middleNav">
     	<ul>
-            <li class="iForum"><a href="http://www.boxbilling.com/forum" target="_blank" title="Invoicing, billing and client management software forum"><span>Forums</span></a></li>
-            <li class="iDocs"><a href="http://docs.boxbilling.com/" target="_blank" title="Invoicing, billing and client management software documentation"><span>Documentation</span></a></li>
+            <li class="iForum"><a href="https://github.com/boxbilling/boxbilling/issues" target="_blank" title="Report a bug on GitHub"><span>Report a bug</span></a></li>
+            <li class="iDocs"><a href="https://docs.boxbilling.com/" target="_blank" title="BoxBilling documentation"><span>Documentation</span></a></li>
         </ul>
     </div>
     <div class="fix"></div>
@@ -33,7 +33,7 @@
 
 <div id="footer">
 	<div class="wrapper">
-       	<span>&copy; Copyright {{ now|date('Y') }}. All rights reserved. Powered by <a href="http://www.boxbilling.com" title="Invoicing, billing and client management software" target="_blank">BoxBilling {{version}}</a></span>
+       	<span>&copy; Copyright {{ now|date('Y') }}. All rights reserved. Powered by <a href="http://www.boxbilling.com" title="BoxBilling" target="_blank">BoxBilling {{version}}</a></span>
     </div>
 </div>
 


### PR DESCRIPTION
This PR will remove links to the dead forum [(it used to be here)](https://boxbilling.com/forum). Nobody moderates it and we now have GitHub Discussions and Issues instead.

I'd still love to hear some thoughts of yours. Have a nice day.