### PR TITLE
Some better security practices

### DIFF
--- a/src/bb-library/Server/Manager/CWP.php
+++ b/src/bb-library/Server/Manager/CWP.php
@@ -322,7 +322,8 @@ class Server_Manager_CWP extends Server_Manager
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt ($ch, CURLOPT_SSL_VERIFYHOST, true);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 		curl_setopt ($ch, CURLOPT_POSTFIELDS, http_build_query($data));
 		curl_setopt ($ch, CURLOPT_POST, 1);
 		$response = json_decode(curl_exec($ch), true);

--- a/src/bb-library/Server/Manager/CWP.php
+++ b/src/bb-library/Server/Manager/CWP.php
@@ -149,11 +149,11 @@ class Server_Manager_CWP extends Server_Manager
 			'action'       => 'add',
 			'domain'       => $a->getDomain(),
 			'user'         => $a->getUsername(),
-			'pass'         => $a->getPassword(),
+			'pass'         => base64_encode($a->getPassword()),
 			'email'        => $client->getEmail(),
 			'package'      => $package,
 			'server_ips'   => $ip,
-			'encodepass'   => false
+			'encodepass'   => true
 		);
 		if($a->getReseller()) {
 			$data['reseller'] = 1;

--- a/src/bb-modules/Invoice/Service.php
+++ b/src/bb-modules/Invoice/Service.php
@@ -631,7 +631,7 @@ class Service implements InjectionAwareInterface
 
                 $new = $this->di['db']->dispense('Invoice');
                 $new->client_id = $invoice->client_id;
-                $new->hash = md5(uniqid());
+                $new->hash = md5(random_bytes(13));
                 $new->status = \Model_Invoice::STATUS_REFUNDED;
                 $new->currency = $invoice->currency;
                 $new->approved = true;

--- a/src/bb-modules/Queue/Api/Admin.php
+++ b/src/bb-modules/Queue/Api/Admin.php
@@ -285,7 +285,7 @@ class Admin extends \Api_Abstract
         
         foreach ($stmt1->fetchAll() as $data) {
             $stmt = $db->prepare($sql2);
-            $stmt->bindValue('handle', md5(uniqid($microtime, true)), \PDO::PARAM_STR);
+            $stmt->bindValue('handle', md5(random_bytes(23)), \PDO::PARAM_STR);
             $stmt->bindValue('id', $data['id'], \PDO::PARAM_INT);
             $stmt->bindValue('timeout', $microtime);
             if ($stmt->execute()) {

--- a/src/bb-modules/Servicesolusvm/Api/Admin.php
+++ b/src/bb-modules/Servicesolusvm/Api/Admin.php
@@ -511,7 +511,7 @@ class Admin extends \Api_Abstract
             if(!in_array($client['id'], $selected)) {
                 continue;
             }
-            $password = substr(md5(uniqid()), 0, 8);
+            $password = substr(md5(random_bytes(13)), 0, 8);
             $cdata = array(
                 'aid'           => $client['id'],
                 'email'         => $client['email'],

--- a/src/install/install.php
+++ b/src/install/install.php
@@ -351,7 +351,7 @@ final class Box_Installer
     {
         $data = [
             'debug' => false,
-            'salt' => md5(uniqid()),
+            'salt' => md5(random_bytes(13)),
             'url' => BB_URL,
             'admin_area_prefix' => '/bb-admin',
             'sef_urls' => true,


### PR DESCRIPTION
`uniqid` is not really cryptographically secure, so instead we should be using `random_bytes` which is.
Still using md5 hashing since it just ensures that the random bytes are hexadecimal. Optionally we should be able to use  another hashing algo or `bin2hex`, but I really need to sit down and learn more about the best practices on those. For now, this is a small, but good improvement.

Also enabled base64 encoding when creating an account with the CWP server manager