### PR TITLE
Attempt to enable PHP8 tests with composer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -34,10 +34,10 @@ body:
       description: We only support between version 7.2 and 7.4, any other version will cause issues and not work.
       multiple: false
       options:
-        - 7.2x
-        - 7.3x
-        - 7.4x
         - Something unsupported
+        - PHP 7.4
+        - PHP 8.0
+        - PHP 8.1
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,6 +10,7 @@ jobs:
   build:
 
     runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 5
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest]

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,11 +10,10 @@ jobs:
   build:
 
     runs-on: ${{ matrix.operating-system }}
-    timeout-minutes: 5
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest]
-        php-versions: ['7.3', '7.4', '8.0']
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.4', '8.0', '8.1']
 
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        operating-system: [ubuntu-latest, windows-latest]
+        php-versions: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -9,10 +9,23 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
 
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+
+    - name: Check PHP Version
+      run: php -v
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -45,26 +58,10 @@ jobs:
         echo > ./src/bb-data/log/php_error.log
         rm -rf ./src/install
 
-    - name: Run test suite for bb-modules on PHP 7.4
-      with:
-        php-version: '7.4'
+    - name: Run test suite for bb-modules
       run: |
         php ./src/bb-vendor/bin/phpunit ./tests/bb-modules/
 
-    - name: Run test suite for bb-library PHP 7.4
-      with:
-        php-version: '7.4'
-      run: |
-        php ./src/bb-vendor/bin/phpunit ./tests/bb-library/
-
-    - name: Run test suite for bb-modules PHP 8
-      with:
-        php-version: '8.0'
-      run: |
-        php ./src/bb-vendor/bin/phpunit ./tests/bb-modules/
-
-    - name: Run test suite for bb-library PHP 8
-      with:
-        php-version: '8.0'
+    - name: Run test suite for bb-library
       run: |
         php ./src/bb-vendor/bin/phpunit ./tests/bb-library/

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -45,10 +45,26 @@ jobs:
         echo > ./src/bb-data/log/php_error.log
         rm -rf ./src/install
 
-    - name: Run test suite for bb-modules
+    - name: Run test suite for bb-modules on PHP 7.4
+      with:
+        php-version: '7.4'
       run: |
         php ./src/bb-vendor/bin/phpunit ./tests/bb-modules/
 
-    - name: Run test suite for bb-library
+    - name: Run test suite for bb-library PHP 7.4
+      with:
+        php-version: '7.4'
+      run: |
+        php ./src/bb-vendor/bin/phpunit ./tests/bb-library/
+
+    - name: Run test suite for bb-modules PHP 8
+      with:
+        php-version: '8.0'
+      run: |
+        php ./src/bb-vendor/bin/phpunit ./tests/bb-modules/
+
+    - name: Run test suite for bb-library PHP 8
+      with:
+        php-version: '8.0'
       run: |
         php ./src/bb-vendor/bin/phpunit ./tests/bb-library/

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0']
 
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ BoxBilling is designed to be extensible and to integrate easily with your favour
 The following environment is highly recommended for running BoxBilling. It *may* be possible to install and run the software in other environments, but it will be untested and unsupported. 
 
 - A suitable web server (Apache/Nginx/LSWS)
-- PHP 7.2, or higher. *Note: PHP 8 is not yet supported.*
+- PHP 7.4, or higher. *Note: PHP 7.2 / 7.3 should work as well, however we don't support them anymore*
 - MySQL 8, or higher. *MariaDB and other direct MySQL compatible DBs also work.*
 - The Following PHP extensions:
     - pdo_mysql

--- a/src/bb-library/Box/Requirements.php
+++ b/src/bb-library/Box/Requirements.php
@@ -41,7 +41,7 @@ class Box_Requirements implements \Box\InjectionAwareInterface
                     'openssl',
                  ),
                 'version'       =>  PHP_VERSION,
-                'min_version'   =>  '7.2',
+                'min_version'   =>  '7.4',
                 'safe_mode'     =>  ini_get('safe_mode'),
             ),
             'writable_folders' => array(


### PR DESCRIPTION
Now that PHP8 should work, let's enable composer tests for it.
Travis is either going to be 7.4 or 8.0 unless there's a way we can modify the docker config to let us test both