### PR TITLE
Fix "8192 Required parameter follows optional parameter"

### DIFF
--- a/src/bb-library/Box/UrlHelper.php
+++ b/src/bb-library/Box/UrlHelper.php
@@ -21,7 +21,7 @@ class Box_UrlHelper {
     /**
      * @param string $requestUri
      */
-    public function __construct($httpMethod, $url, $conditions=array(), $requestUri) {
+    public function __construct($httpMethod, $url, $conditions, $requestUri) {
 
         $requestMethod = $_SERVER['REQUEST_METHOD'];
         $this->method = $httpMethod;

--- a/src/bb-modules/Product/Service.php
+++ b/src/bb-modules/Product/Service.php
@@ -541,7 +541,7 @@ class Service implements InjectionAwareInterface
         return array($sql, $params);
     }
 
-    public function createPromo($code, $type, $value, $products = array(), $periods = array(), $clientGroups = array(), $data)
+    public function createPromo($code, $type, $value, $products, $periods, $clientGroups, $data)
     {
         if ($this->di['db']->findOne('Promo', 'code = :code', array(':code' => $code))) {
             throw new \Box_Exception('This promo code already exists.');


### PR DESCRIPTION
Because these have a "default" value, it throws this error:
`8192 Required parameter $data follows optional parameter $products /bb-modules/Product/Service.php 544`

- and -

`8192 Required parameter $requestUri follows optional parameter $conditions /bb-library/Box/UrlHelper.php 24`

This shouldn't be required