### PR TITLE
Update broken stylesheet path in a default theme page

### DIFF
--- a/src/bb-themes/boxbilling/html/mod_page_preview_markdown.phtml
+++ b/src/bb-themes/boxbilling/html/mod_page_preview_markdown.phtml
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>Markdown preview</title>
-{{ 'style.css' | asset_url | stylesheet_tag }}
+{{ 'css/style.css' | asset_url | stylesheet_tag }}
 </head>
 <body style="background-color: white; padding:10px;">
     <div class="markdown">


### PR DESCRIPTION
Should close #898. Tiny commit.

I can't see where this is used, but this is the only reference to the wrong css file in this theme, as far as I can tell.

