### PR TITLE
Removed the license fallback in mod.php

### DIFF
--- a/src/bb-library/Box/Mod.php
+++ b/src/bb-library/Box/Mod.php
@@ -92,7 +92,7 @@ class Box_Mod
             'homepage_url'  => 'https://github.com/boxbilling/',
             'author'        => 'BoxBilling',
             'author_url'    => 'https://extensions.boxbilling.com/',
-            'license'       => 'GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html',
+            'license'       => 'N/A',
             'version'       => '1.0',
             'icon_url'      => NULL,
             'download_url'  => NULL,


### PR DESCRIPTION
We can't display a "fallback license" as it would be misleading. Unless the extension owner specifies a license on their own, we can't really show their code like it's licensed under GPLv2.