### PR TITLE
Fix PDF generation on PHP 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ BoxBilling is designed to be extensible and to integrate easily with your favour
 The following environment is highly recommended for running BoxBilling. It *may* be possible to install and run the software in other environments, but it will be untested and unsupported. 
 
 - A suitable web server (Apache/Nginx/LSWS)
-- PHP 7.4, or higher. *Note: PHP 7.2 / 7.3 should work as well, however we don't support them anymore*
+- PHP 7.4, or higher.
+  - *We recommended PHP 7.4 over PHP 8 as it's been more thoroughly tested, however both should work*
 - MySQL 8, or higher. *MariaDB and other direct MySQL compatible DBs also work.*
 - The Following PHP extensions:
     - pdo_mysql

--- a/src/bb-library/PDF_ImageAlpha.php
+++ b/src/bb-library/PDF_ImageAlpha.php
@@ -149,8 +149,7 @@ function Close()
 function _putimages()
 {
     $filter=($this->compress) ? '/Filter /FlateDecode ' : '';
-    reset($this->images);
-    while(list($file,$info)=each($this->images))
+    foreach($this->images as $file => $info)
     {
         $this->_newobj();
         $this->images[$file]['n']=$this->n;


### PR DESCRIPTION
We still need  to replace TFPDF, but this is enough for now.
Additionally, make a note that PHP 7.4 is recommended over PHP 8 for the time being since it's been tested more toughly 