### PR TITLE
Fix copyright URL

### DIFF
--- a/src/bb-cron.php
+++ b/src/bb-cron.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-di.php
+++ b/src/bb-di.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-ipn.php
+++ b/src/bb-ipn.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Api/Abstract.php
+++ b/src/bb-library/Api/Abstract.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Api/Handler.php
+++ b/src/bb-library/Api/Handler.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/App.php
+++ b/src/bb-library/Box/App.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/AppAdmin.php
+++ b/src/bb-library/Box/AppAdmin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/AppClient.php
+++ b/src/bb-library/Box/AppClient.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Authorization.php
+++ b/src/bb-library/Box/Authorization.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/BeanHelper.php
+++ b/src/bb-library/Box/BeanHelper.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Config.php
+++ b/src/bb-library/Box/Config.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Cookie.php
+++ b/src/bb-library/Box/Cookie.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Crypt.php
+++ b/src/bb-library/Box/Crypt.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Curl.php
+++ b/src/bb-library/Box/Curl.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Database.php
+++ b/src/bb-library/Box/Database.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/DbLoggedPDOStatement.php
+++ b/src/bb-library/Box/DbLoggedPDOStatement.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Di.php
+++ b/src/bb-library/Box/Di.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Event.php
+++ b/src/bb-library/Box/Event.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/EventDispatcher.php
+++ b/src/bb-library/Box/EventDispatcher.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/EventManager.php
+++ b/src/bb-library/Box/EventManager.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Exception.php
+++ b/src/bb-library/Box/Exception.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/ExceptionAuth.php
+++ b/src/bb-library/Box/ExceptionAuth.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Extension.php
+++ b/src/bb-library/Box/Extension.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Ftp.php
+++ b/src/bb-library/Box/Ftp.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/InjectionAwareInterface.php
+++ b/src/bb-library/Box/InjectionAwareInterface.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Log.php
+++ b/src/bb-library/Box/Log.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/LogDb.php
+++ b/src/bb-library/Box/LogDb.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/LogStream.php
+++ b/src/bb-library/Box/LogStream.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Mail.php
+++ b/src/bb-library/Box/Mail.php
@@ -2,25 +2,13 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc
  * This source file is subject to the Apache-2.0 License that is bundled
  * with this source code in the file LICENSE
  */
-
-/**
- * BoxBilling
- *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
- * @license   Apache-2.0
- *
- * Copyright BoxBilling, Inc
- * This source file is subject to the Apache-2.0 License that is bundled
- * with this source code in the file LICENSE
- */
-
 
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;

--- a/src/bb-library/Box/Mod.php
+++ b/src/bb-library/Box/Mod.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Pagination.php
+++ b/src/bb-library/Box/Pagination.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Paginator.php
+++ b/src/bb-library/Box/Paginator.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Paginator.php
+++ b/src/bb-library/Box/Paginator.php
@@ -1,16 +1,5 @@
 <?php
 /**
- * BoxBilling
- *
- * @copyright BoxBilling, Inc (https://www.boxbilling.org)
- * @license   Apache-2.0
- *
- * Copyright BoxBilling, Inc
- * This source file is subject to the Apache-2.0 License that is bundled
- * with this source code in the file LICENSE
- */
-
-/**
  * Class to paginate a list of items in a old digg style
  * 
  * @see https://github.com/gigo6000/Symfony2-Pagination-Class
@@ -18,7 +7,9 @@
  * @author Carlos Mafla <gigo6000@hotmail.com>
  * @www.inchoo.net
  */
-class Box_Paginator {
+class Box_Paginator extends Paginator {}
+
+class Paginator {
 
     /**
      * @var int current displayed page

--- a/src/bb-library/Box/Password.php
+++ b/src/bb-library/Box/Password.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Period.php
+++ b/src/bb-library/Box/Period.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Request.php
+++ b/src/bb-library/Box/Request.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/RequestFile.php
+++ b/src/bb-library/Box/RequestFile.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Requirements.php
+++ b/src/bb-library/Box/Requirements.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Response.php
+++ b/src/bb-library/Box/Response.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Session.php
+++ b/src/bb-library/Box/Session.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Tools.php
+++ b/src/bb-library/Box/Tools.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Translate.php
+++ b/src/bb-library/Box/Translate.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/TwigExtensions.php
+++ b/src/bb-library/Box/TwigExtensions.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/TwigLoader.php
+++ b/src/bb-library/Box/TwigLoader.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Update.php
+++ b/src/bb-library/Box/Update.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Url.php
+++ b/src/bb-library/Box/Url.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/UrlHelper.php
+++ b/src/bb-library/Box/UrlHelper.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Validate.php
+++ b/src/bb-library/Box/Validate.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Version.php
+++ b/src/bb-library/Box/Version.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Box/Zip.php
+++ b/src/bb-library/Box/Zip.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/FileCache.php
+++ b/src/bb-library/FileCache.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ActivityAdminHistory.php
+++ b/src/bb-library/Model/ActivityAdminHistory.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ActivityClientEmail.php
+++ b/src/bb-library/Model/ActivityClientEmail.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ActivityClientHistory.php
+++ b/src/bb-library/Model/ActivityClientHistory.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ActivityClientHistoryTable.php
+++ b/src/bb-library/Model/ActivityClientHistoryTable.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ActivitySystem.php
+++ b/src/bb-library/Model/ActivitySystem.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Admin.php
+++ b/src/bb-library/Model/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/AdminGroup.php
+++ b/src/bb-library/Model/AdminGroup.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ApiRequest.php
+++ b/src/bb-library/Model/ApiRequest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ApiRequestTable.php
+++ b/src/bb-library/Model/ApiRequestTable.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Cart.php
+++ b/src/bb-library/Model/Cart.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/CartProduct.php
+++ b/src/bb-library/Model/CartProduct.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Client.php
+++ b/src/bb-library/Model/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ClientBalance.php
+++ b/src/bb-library/Model/ClientBalance.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ClientGroup.php
+++ b/src/bb-library/Model/ClientGroup.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ClientOrder.php
+++ b/src/bb-library/Model/ClientOrder.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ClientOrderMeta.php
+++ b/src/bb-library/Model/ClientOrderMeta.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ClientOrderStatus.php
+++ b/src/bb-library/Model/ClientOrderStatus.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ClientPasswordReset.php
+++ b/src/bb-library/Model/ClientPasswordReset.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ClientPasswordResetTable.php
+++ b/src/bb-library/Model/ClientPasswordResetTable.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Currency.php
+++ b/src/bb-library/Model/Currency.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/EmailTemplate.php
+++ b/src/bb-library/Model/EmailTemplate.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Extension.php
+++ b/src/bb-library/Model/Extension.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ExtensionMeta.php
+++ b/src/bb-library/Model/ExtensionMeta.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Form.php
+++ b/src/bb-library/Model/Form.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/FormField.php
+++ b/src/bb-library/Model/FormField.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Forum.php
+++ b/src/bb-library/Model/Forum.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ForumTable.php
+++ b/src/bb-library/Model/ForumTable.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ForumTopic.php
+++ b/src/bb-library/Model/ForumTopic.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ForumTopicMessage.php
+++ b/src/bb-library/Model/ForumTopicMessage.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ForumTopicMessageTable.php
+++ b/src/bb-library/Model/ForumTopicMessageTable.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ForumTopicTable.php
+++ b/src/bb-library/Model/ForumTopicTable.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Guest.php
+++ b/src/bb-library/Model/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Invoice.php
+++ b/src/bb-library/Model/Invoice.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/InvoiceItem.php
+++ b/src/bb-library/Model/InvoiceItem.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/KbArticle.php
+++ b/src/bb-library/Model/KbArticle.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/KbArticleCategory.php
+++ b/src/bb-library/Model/KbArticleCategory.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ModEmailQueue.php
+++ b/src/bb-library/Model/ModEmailQueue.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/PayGateway.php
+++ b/src/bb-library/Model/PayGateway.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Post.php
+++ b/src/bb-library/Model/Post.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Product.php
+++ b/src/bb-library/Model/Product.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ProductCategory.php
+++ b/src/bb-library/Model/ProductCategory.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ProductCustom.php
+++ b/src/bb-library/Model/ProductCustom.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ProductDomain.php
+++ b/src/bb-library/Model/ProductDomain.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ProductDomainTable.php
+++ b/src/bb-library/Model/ProductDomainTable.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ProductDownloadable.php
+++ b/src/bb-library/Model/ProductDownloadable.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ProductHosting.php
+++ b/src/bb-library/Model/ProductHosting.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ProductLicense.php
+++ b/src/bb-library/Model/ProductLicense.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ProductMembership.php
+++ b/src/bb-library/Model/ProductMembership.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ProductPayment.php
+++ b/src/bb-library/Model/ProductPayment.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ProductTable.php
+++ b/src/bb-library/Model/ProductTable.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Promo.php
+++ b/src/bb-library/Model/Promo.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ServiceCustom.php
+++ b/src/bb-library/Model/ServiceCustom.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ServiceDomain.php
+++ b/src/bb-library/Model/ServiceDomain.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ServiceDownloadable.php
+++ b/src/bb-library/Model/ServiceDownloadable.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ServiceHosting.php
+++ b/src/bb-library/Model/ServiceHosting.php
@@ -3,7 +3,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ServiceHostingHp.php
+++ b/src/bb-library/Model/ServiceHostingHp.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ServiceHostingServer.php
+++ b/src/bb-library/Model/ServiceHostingServer.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ServiceLicense.php
+++ b/src/bb-library/Model/ServiceLicense.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/ServiceMembership.php
+++ b/src/bb-library/Model/ServiceMembership.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Session.php
+++ b/src/bb-library/Model/Session.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Setting.php
+++ b/src/bb-library/Model/Setting.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Subscription.php
+++ b/src/bb-library/Model/Subscription.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/SupportHelpdesk.php
+++ b/src/bb-library/Model/SupportHelpdesk.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/SupportPTicket.php
+++ b/src/bb-library/Model/SupportPTicket.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/SupportPTicketMessage.php
+++ b/src/bb-library/Model/SupportPTicketMessage.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/SupportPr.php
+++ b/src/bb-library/Model/SupportPr.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/SupportPrCategory.php
+++ b/src/bb-library/Model/SupportPrCategory.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/SupportTicket.php
+++ b/src/bb-library/Model/SupportTicket.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/SupportTicketMessage.php
+++ b/src/bb-library/Model/SupportTicketMessage.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/SupportTicketNote.php
+++ b/src/bb-library/Model/SupportTicketNote.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Tax.php
+++ b/src/bb-library/Model/Tax.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Tld.php
+++ b/src/bb-library/Model/Tld.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/TldRegistrar.php
+++ b/src/bb-library/Model/TldRegistrar.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Model/Transaction.php
+++ b/src/bb-library/Model/Transaction.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Adapter/AliPay.php
+++ b/src/bb-library/Payment/Adapter/AliPay.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Adapter/AuthorizeNet.php
+++ b/src/bb-library/Payment/Adapter/AuthorizeNet.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Adapter/ClientBalance.php
+++ b/src/bb-library/Payment/Adapter/ClientBalance.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Adapter/Custom.php
+++ b/src/bb-library/Payment/Adapter/Custom.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Adapter/Interkassa.php
+++ b/src/bb-library/Payment/Adapter/Interkassa.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Adapter/Onebip.php
+++ b/src/bb-library/Payment/Adapter/Onebip.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Adapter/PayPalEmail.php
+++ b/src/bb-library/Payment/Adapter/PayPalEmail.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Adapter/Stripe.php
+++ b/src/bb-library/Payment/Adapter/Stripe.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Adapter/TwoCheckout.php
+++ b/src/bb-library/Payment/Adapter/TwoCheckout.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Adapter/WebMoney.php
+++ b/src/bb-library/Payment/Adapter/WebMoney.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/AdapterAbstract.php
+++ b/src/bb-library/Payment/AdapterAbstract.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Exception.php
+++ b/src/bb-library/Payment/Exception.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Invoice.php
+++ b/src/bb-library/Payment/Invoice.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Invoice/Buyer.php
+++ b/src/bb-library/Payment/Invoice/Buyer.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Invoice/Item.php
+++ b/src/bb-library/Payment/Invoice/Item.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Invoice/Subscription.php
+++ b/src/bb-library/Payment/Invoice/Subscription.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Payment/Transaction.php
+++ b/src/bb-library/Payment/Transaction.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Registrar/Adapter/Email.php
+++ b/src/bb-library/Registrar/Adapter/Email.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Registrar/Adapter/Resellerclub.php
+++ b/src/bb-library/Registrar/Adapter/Resellerclub.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Registrar/Adapter/srsx.php
+++ b/src/bb-library/Registrar/Adapter/srsx.php
@@ -12,7 +12,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@boxbilling.com so we can send you a copy immediately.
  *
- * @copyright Copyright (c) 2010-2020 BoxBilling (http://www.boxbilling.com)
+ * @copyright Copyright (c) 2010-2020 BoxBilling (https://www.boxbilling.org)
  * @license   http://www.boxbilling.com/LICENSE.txt
  * @version   $Id$
  * Created by bayamsoftware.com & @timothygwebb

--- a/src/bb-library/Server/Account.php
+++ b/src/bb-library/Server/Account.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Server/Client.php
+++ b/src/bb-library/Server/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Server/Exception.php
+++ b/src/bb-library/Server/Exception.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Server/Manager.php
+++ b/src/bb-library/Server/Manager.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Server/Manager/CWP.php
+++ b/src/bb-library/Server/Manager/CWP.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Server/Manager/Custom.php
+++ b/src/bb-library/Server/Manager/Custom.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Server/Manager/Directadmin.php
+++ b/src/bb-library/Server/Manager/Directadmin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Server/Manager/Ispconfig3.php
+++ b/src/bb-library/Server/Manager/Ispconfig3.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Server/Manager/MOFH.php
+++ b/src/bb-library/Server/Manager/MOFH.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Server/Manager/Virtualmin.php
+++ b/src/bb-library/Server/Manager/Virtualmin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Server/Manager/Whm.php
+++ b/src/bb-library/Server/Manager/Whm.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-library/Server/Package.php
+++ b/src/bb-library/Server/Package.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-load.php
+++ b/src/bb-load.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Activity/Api/Admin.php
+++ b/src/bb-modules/Activity/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Activity/Controller/Admin.php
+++ b/src/bb-modules/Activity/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Activity/Service.php
+++ b/src/bb-modules/Activity/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Api/Controller/Client.php
+++ b/src/bb-modules/Api/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Api/Service.php
+++ b/src/bb-modules/Api/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Branding/Service.php
+++ b/src/bb-modules/Branding/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Cart/Api/Admin.php
+++ b/src/bb-modules/Cart/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Cart/Api/Client.php
+++ b/src/bb-modules/Cart/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Cart/Api/Guest.php
+++ b/src/bb-modules/Cart/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Cart/Controller/Client.php
+++ b/src/bb-modules/Cart/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Cart/Service.php
+++ b/src/bb-modules/Cart/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Client/Api/Admin.php
+++ b/src/bb-modules/Client/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Client/Api/Client.php
+++ b/src/bb-modules/Client/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Client/Api/Guest.php
+++ b/src/bb-modules/Client/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Client/Controller/Admin.php
+++ b/src/bb-modules/Client/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Client/Controller/Client.php
+++ b/src/bb-modules/Client/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Client/Service.php
+++ b/src/bb-modules/Client/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Client/ServiceBalance.php
+++ b/src/bb-modules/Client/ServiceBalance.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Cookieconsent/Api/Guest.php
+++ b/src/bb-modules/Cookieconsent/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Cookieconsent/Controller/Admin.php
+++ b/src/bb-modules/Cookieconsent/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Cookieconsent/Service.php
+++ b/src/bb-modules/Cookieconsent/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Cron/Api/Admin.php
+++ b/src/bb-modules/Cron/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Cron/Api/Guest.php
+++ b/src/bb-modules/Cron/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Cron/Service.php
+++ b/src/bb-modules/Cron/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Currency/Api/Admin.php
+++ b/src/bb-modules/Currency/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Currency/Api/Guest.php
+++ b/src/bb-modules/Currency/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Currency/Controller/Admin.php
+++ b/src/bb-modules/Currency/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Currency/Service.php
+++ b/src/bb-modules/Currency/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Custompages/Api/Admin.php
+++ b/src/bb-modules/Custompages/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Custompages/Controller/Admin.php
+++ b/src/bb-modules/Custompages/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Custompages/Controller/Client.php
+++ b/src/bb-modules/Custompages/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Custompages/Service.php
+++ b/src/bb-modules/Custompages/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Dashboard/Controller/Client.php
+++ b/src/bb-modules/Dashboard/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Email/Api/Admin.php
+++ b/src/bb-modules/Email/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Email/Api/Client.php
+++ b/src/bb-modules/Email/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Email/Controller/Admin.php
+++ b/src/bb-modules/Email/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Email/Controller/Client.php
+++ b/src/bb-modules/Email/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Email/Service.php
+++ b/src/bb-modules/Email/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Embed/Controller/Admin.php
+++ b/src/bb-modules/Embed/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Embed/Controller/Client.php
+++ b/src/bb-modules/Embed/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Example/Api/Admin.php
+++ b/src/bb-modules/Example/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Example/Api/Client.php
+++ b/src/bb-modules/Example/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Example/Api/Guest.php
+++ b/src/bb-modules/Example/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Example/Controller/Admin.php
+++ b/src/bb-modules/Example/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Example/Controller/Client.php
+++ b/src/bb-modules/Example/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Example/Service.php
+++ b/src/bb-modules/Example/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Extension/Api/Admin.php
+++ b/src/bb-modules/Extension/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Extension/Api/Guest.php
+++ b/src/bb-modules/Extension/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Extension/Controller/Admin.php
+++ b/src/bb-modules/Extension/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Extension/Service.php
+++ b/src/bb-modules/Extension/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Formbuilder/Api/Admin.php
+++ b/src/bb-modules/Formbuilder/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Formbuilder/Api/Guest.php
+++ b/src/bb-modules/Formbuilder/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Formbuilder/Controller/Client.php
+++ b/src/bb-modules/Formbuilder/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Formbuilder/Service.php
+++ b/src/bb-modules/Formbuilder/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Forum/Api/Admin.php
+++ b/src/bb-modules/Forum/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Forum/Api/Client.php
+++ b/src/bb-modules/Forum/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Forum/Api/Guest.php
+++ b/src/bb-modules/Forum/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Forum/Controller/Admin.php
+++ b/src/bb-modules/Forum/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Forum/Controller/Client.php
+++ b/src/bb-modules/Forum/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Forum/Service.php
+++ b/src/bb-modules/Forum/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Hook/Api/Admin.php
+++ b/src/bb-modules/Hook/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Hook/Service.php
+++ b/src/bb-modules/Hook/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Index/Controller/Admin.php
+++ b/src/bb-modules/Index/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Invoice/Api/Admin.php
+++ b/src/bb-modules/Invoice/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Invoice/Api/Client.php
+++ b/src/bb-modules/Invoice/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Invoice/Api/Guest.php
+++ b/src/bb-modules/Invoice/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Invoice/Controller/Admin.php
+++ b/src/bb-modules/Invoice/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Invoice/Controller/Client.php
+++ b/src/bb-modules/Invoice/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Invoice/Service.php
+++ b/src/bb-modules/Invoice/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Invoice/ServiceInvoiceItem.php
+++ b/src/bb-modules/Invoice/ServiceInvoiceItem.php
@@ -2,7 +2,7 @@
 /**
 * BoxBilling
 *
-* @copyright BoxBilling, Inc (http://www.boxbilling.com)
+* @copyright BoxBilling, Inc (https://www.boxbilling.org)
 * @license   Apache-2.0
 *
 * Copyright BoxBilling, Inc

--- a/src/bb-modules/Invoice/ServicePayGateway.php
+++ b/src/bb-modules/Invoice/ServicePayGateway.php
@@ -2,7 +2,7 @@
 /**
 * BoxBilling
 *
-* @copyright BoxBilling, Inc (http://www.boxbilling.com)
+* @copyright BoxBilling, Inc (https://www.boxbilling.org)
 * @license   Apache-2.0
 *
 * Copyright BoxBilling, Inc

--- a/src/bb-modules/Invoice/ServiceSubscription.php
+++ b/src/bb-modules/Invoice/ServiceSubscription.php
@@ -2,7 +2,7 @@
 /**
 * BoxBilling
 *
-* @copyright BoxBilling, Inc (http://www.boxbilling.com)
+* @copyright BoxBilling, Inc (https://www.boxbilling.org)
 * @license   Apache-2.0
 *
 * Copyright BoxBilling, Inc

--- a/src/bb-modules/Invoice/ServiceTax.php
+++ b/src/bb-modules/Invoice/ServiceTax.php
@@ -2,7 +2,7 @@
 /**
 * BoxBilling
 *
-* @copyright BoxBilling, Inc (http://www.boxbilling.com)
+* @copyright BoxBilling, Inc (https://www.boxbilling.org)
 * @license   Apache-2.0
 *
 * Copyright BoxBilling, Inc

--- a/src/bb-modules/Invoice/ServiceTransaction.php
+++ b/src/bb-modules/Invoice/ServiceTransaction.php
@@ -2,7 +2,7 @@
 /**
 * BoxBilling
 *
-* @copyright BoxBilling, Inc (http://www.boxbilling.com)
+* @copyright BoxBilling, Inc (https://www.boxbilling.org)
 * @license   Apache-2.0
 *
 * Copyright BoxBilling, Inc

--- a/src/bb-modules/Kb/Api/Admin.php
+++ b/src/bb-modules/Kb/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Kb/Api/Guest.php
+++ b/src/bb-modules/Kb/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Kb/Controller/Admin.php
+++ b/src/bb-modules/Kb/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Kb/Controller/Client.php
+++ b/src/bb-modules/Kb/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Kb/Service.php
+++ b/src/bb-modules/Kb/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Massmailer/Api/Admin.php
+++ b/src/bb-modules/Massmailer/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Massmailer/Controller/Admin.php
+++ b/src/bb-modules/Massmailer/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Massmailer/Service.php
+++ b/src/bb-modules/Massmailer/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/News/Api/Admin.php
+++ b/src/bb-modules/News/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/News/Api/Guest.php
+++ b/src/bb-modules/News/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/News/Controller/Admin.php
+++ b/src/bb-modules/News/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/News/Controller/Client.php
+++ b/src/bb-modules/News/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/News/Service.php
+++ b/src/bb-modules/News/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Notification/Api/Admin.php
+++ b/src/bb-modules/Notification/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Notification/Controller/Admin.php
+++ b/src/bb-modules/Notification/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Notification/Service.php
+++ b/src/bb-modules/Notification/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Order/Api/Admin.php
+++ b/src/bb-modules/Order/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Order/Api/Client.php
+++ b/src/bb-modules/Order/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Order/Controller/Admin.php
+++ b/src/bb-modules/Order/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Order/Controller/Client.php
+++ b/src/bb-modules/Order/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Order/Service.php
+++ b/src/bb-modules/Order/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Orderbutton/Controller/Client.php
+++ b/src/bb-modules/Orderbutton/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Page/Api/Admin.php
+++ b/src/bb-modules/Page/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Page/Service.php
+++ b/src/bb-modules/Page/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Paidsupport/Service.php
+++ b/src/bb-modules/Paidsupport/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Product/Api/Admin.php
+++ b/src/bb-modules/Product/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Product/Api/Guest.php
+++ b/src/bb-modules/Product/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Product/Controller/Admin.php
+++ b/src/bb-modules/Product/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Product/Service.php
+++ b/src/bb-modules/Product/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Profile/Api/Admin.php
+++ b/src/bb-modules/Profile/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Profile/Api/Client.php
+++ b/src/bb-modules/Profile/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Profile/Service.php
+++ b/src/bb-modules/Profile/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Queue/Api/Admin.php
+++ b/src/bb-modules/Queue/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Queue/Service.php
+++ b/src/bb-modules/Queue/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Redirect/Api/Admin.php
+++ b/src/bb-modules/Redirect/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Redirect/Controller/Client.php
+++ b/src/bb-modules/Redirect/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Redirect/Service.php
+++ b/src/bb-modules/Redirect/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Seo/Service.php
+++ b/src/bb-modules/Seo/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicecentovacast/Api/Admin.php
+++ b/src/bb-modules/Servicecentovacast/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicecentovacast/Api/Client.php
+++ b/src/bb-modules/Servicecentovacast/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicecentovacast/Service.php
+++ b/src/bb-modules/Servicecentovacast/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicecustom/Api/Admin.php
+++ b/src/bb-modules/Servicecustom/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicecustom/Api/Client.php
+++ b/src/bb-modules/Servicecustom/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicecustom/Service.php
+++ b/src/bb-modules/Servicecustom/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicedomain/Api/Admin.php
+++ b/src/bb-modules/Servicedomain/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicedomain/Api/Client.php
+++ b/src/bb-modules/Servicedomain/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicedomain/Api/Guest.php
+++ b/src/bb-modules/Servicedomain/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicedomain/Controller/Admin.php
+++ b/src/bb-modules/Servicedomain/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicedomain/Service.php
+++ b/src/bb-modules/Servicedomain/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicedomain/ServiceTld.php
+++ b/src/bb-modules/Servicedomain/ServiceTld.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicedownloadable/Api/Admin.php
+++ b/src/bb-modules/Servicedownloadable/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicedownloadable/Api/Client.php
+++ b/src/bb-modules/Servicedownloadable/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicedownloadable/Controller/Client.php
+++ b/src/bb-modules/Servicedownloadable/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicedownloadable/Service.php
+++ b/src/bb-modules/Servicedownloadable/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicehosting/Api/Admin.php
+++ b/src/bb-modules/Servicehosting/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicehosting/Api/Client.php
+++ b/src/bb-modules/Servicehosting/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicehosting/Api/Guest.php
+++ b/src/bb-modules/Servicehosting/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicehosting/Controller/Admin.php
+++ b/src/bb-modules/Servicehosting/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicehosting/Service.php
+++ b/src/bb-modules/Servicehosting/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicelicense/Api/Admin.php
+++ b/src/bb-modules/Servicelicense/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicelicense/Api/Client.php
+++ b/src/bb-modules/Servicelicense/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicelicense/Api/Guest.php
+++ b/src/bb-modules/Servicelicense/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicelicense/Plugin/Simple.php
+++ b/src/bb-modules/Servicelicense/Plugin/Simple.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicelicense/Server.php
+++ b/src/bb-modules/Servicelicense/Server.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicelicense/Service.php
+++ b/src/bb-modules/Servicelicense/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicemembership/Service.php
+++ b/src/bb-modules/Servicemembership/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicesolusvm/Api/Admin.php
+++ b/src/bb-modules/Servicesolusvm/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicesolusvm/Api/Client.php
+++ b/src/bb-modules/Servicesolusvm/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicesolusvm/Api/Guest.php
+++ b/src/bb-modules/Servicesolusvm/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicesolusvm/Controller/Admin.php
+++ b/src/bb-modules/Servicesolusvm/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Servicesolusvm/Service.php
+++ b/src/bb-modules/Servicesolusvm/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Spamchecker/Api/Guest.php
+++ b/src/bb-modules/Spamchecker/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Spamchecker/Service.php
+++ b/src/bb-modules/Spamchecker/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Staff/Api/Admin.php
+++ b/src/bb-modules/Staff/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Staff/Api/Guest.php
+++ b/src/bb-modules/Staff/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Staff/Controller/Admin.php
+++ b/src/bb-modules/Staff/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Staff/Service.php
+++ b/src/bb-modules/Staff/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Stats/Api/Admin.php
+++ b/src/bb-modules/Stats/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Stats/Service.php
+++ b/src/bb-modules/Stats/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Support/Api/Admin.php
+++ b/src/bb-modules/Support/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Support/Api/Client.php
+++ b/src/bb-modules/Support/Api/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Support/Api/Guest.php
+++ b/src/bb-modules/Support/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Support/Controller/Admin.php
+++ b/src/bb-modules/Support/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Support/Controller/Client.php
+++ b/src/bb-modules/Support/Controller/Client.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Support/Service.php
+++ b/src/bb-modules/Support/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/System/Api/Admin.php
+++ b/src/bb-modules/System/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/System/Api/Guest.php
+++ b/src/bb-modules/System/Api/Guest.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/System/Controller/Admin.php
+++ b/src/bb-modules/System/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/System/Service.php
+++ b/src/bb-modules/System/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Theme/Api/Admin.php
+++ b/src/bb-modules/Theme/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Theme/Controller/Admin.php
+++ b/src/bb-modules/Theme/Controller/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Theme/Model/Theme.php
+++ b/src/bb-modules/Theme/Model/Theme.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Theme/Service.php
+++ b/src/bb-modules/Theme/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Wysiwyg/Api/Admin.php
+++ b/src/bb-modules/Wysiwyg/Api/Admin.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-modules/Wysiwyg/Service.php
+++ b/src/bb-modules/Wysiwyg/Service.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/bb-update.php
+++ b/src/bb-update.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc

--- a/src/index.php
+++ b/src/index.php
@@ -2,7 +2,7 @@
 /**
  * BoxBilling
  *
- * @copyright BoxBilling, Inc (http://www.boxbilling.com)
+ * @copyright BoxBilling, Inc (https://www.boxbilling.org)
  * @license   Apache-2.0
  *
  * Copyright BoxBilling, Inc


### PR DESCRIPTION
Replacing boxbilling.com with boxbilling.org.

Also, can someone comment on the `Paginator.php` file? I removed our copyright from it and reverted the classname to it's original in this [commit](https://github.com/boxbilling/boxbilling/commit/c28bbf2dc54c9dcaaca0716ecec46e10065c641b), but I don't know the original source for it. The repository is called "Symfony2-Pagination-Class", does that mean it came from Symfony? I really don't know.

Edit: it looks like the code is NOT part of Symfony, judging by the text on [this page](http://devtime.blogspot.com/2011/05/symfony2-twig-pagination-class.html). No license is given in the source, so I don't know