### PR TITLE
Replacing links with dynamic redirects from the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Your [pull requests](https://github.com/boxbilling/boxbilling/pulls) will be hig
 
 **Got questions? Found a bug? Ideas for improvements?**
 
-Don't hesitate to create an [issue](https://github.com/boxbilling/boxbilling/issues), or join us on [Slack](https://boxbilling.slack.com/) to say hi.
+Don't hesitate to create an [issue](https://github.com/boxbilling/boxbilling/issues), or join us on [Slack](https://boxbilling.org/slack) to say hi.
 
 ⭐ Not a developer? Feel free to help by starring the repository. It helps us catching attention of new developers who'd like to contribute. 
 
@@ -151,5 +151,5 @@ This product includes GeoLite2 data created by MaxMind, available from [https://
 
 * [Website](https://www.boxbilling.org/)
 * [Documentation](https://docs.boxbilling.com/)
-* [Discord](https://discord.gg/xFfPmNTU7R)
-* [Slack](https://boxbilling.slack.com/)
+* [Discord](https://boxbilling.org/discord)
+* [Slack](https://boxbilling.org/slack)


### PR DESCRIPTION
Now they won't break if the invites need to be changed for some reason.