### PR TITLE
Fix file_get_contents offset

### DIFF
--- a/src/bb-library/Box/Tools.php
+++ b/src/bb-library/Box/Tools.php
@@ -55,7 +55,7 @@ class Box_Tools
         }
     }
 
-    public function file_get_contents($filename, $use_include_path = false, $context = null, $offset = -1, $useoffset = true)
+    public function file_get_contents($filename, $use_include_path = false, $context = null, $offset = 0, $useoffset = true)
     {
         if($useoffset){
             return file_get_contents($filename, $use_include_path, $context, $offset);


### PR DESCRIPTION
It used to start reading from the last character of the file, so it just returned the last character of the whole file. Making the default offset 0, the function now reads and returns the whole content from the beginning to the end.