### PR TITLE
Automatically forward to the installer

### DIFF
--- a/src/bb-load.php
+++ b/src/bb-load.php
@@ -251,7 +251,7 @@ if(!file_exists($configPath) || 0 == filesize($configPath)) {
     }
 
     $configFile = pathinfo($configPath, PATHINFO_BASENAME);
-    $msg = sprintf("Your <b><em>$configFile</em></b> file seems to be invalid. It's possible that your preexisting configuration file may not contain the required configuration parameters or have become corrupted. BoxBilling needs to have a valid configuration file present in order to function properly.</p> <p>Please us the example config as reference <a target='_blank' href='https://raw.githubusercontent.com/boxbilling/boxbilling/master/src/bb-config-sample.php'>here</a>. You may need to manually restore a old config file or fix your existing one.</p>");
+    $msg = sprintf("Your <b><em>$configFile</em></b> file seems to be invalid. It's possible that your preexisting configuration file may not contain the required configuration parameters or have become corrupted. BoxBilling needs to have a valid configuration file present in order to function properly.</p> <p>Please use the example config as reference <a target='_blank' href='https://raw.githubusercontent.com/boxbilling/boxbilling/master/src/bb-config-sample.php'>here</a>. You may need to manually restore a old config file or fix your existing one.</p>");
     throw new Exception($msg, 101);
 }
 


### PR DESCRIPTION
If the installer still exists on the disk and the config is broken / none-existent, forward to the installer automatically.
Close issue #937

If the installer does not exist on disk, then it was a finished install and there is indeed an error and then the old behavior is fine, otherwise it's a new install and it makes sense to just go straight to the installer