### PR TITLE
bootstrap: Replace text under the "Contact Us" panel

### DIFF
--- a/src/bb-themes/bootstrap/html/mod_index_dashboard.phtml
+++ b/src/bb-themes/bootstrap/html/mod_index_dashboard.phtml
@@ -284,7 +284,7 @@
 						</div>
 						<div class="panel-body">
 							<h4><a href="{{ '/support/contact-us'|link }}">{% trans 'Contact Us' %}</a></h4>
-							<p>{{ company.signature }}</p>
+							<p>Get assistance for your service</p>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
IMO it shouldn't display the company signature there.