### PR TITLE
Admin theme re-design.

### DIFF
--- a/src/bb-themes/admin_default/css/min.css
+++ b/src/bb-themes/admin_default/css/min.css
@@ -1,1 +1,11070 @@
-.sprite-abacus{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 0;width:14px;height:14px}.sprite-add{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px 0;width:14px;height:14px}.sprite-addressBook{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -14px;width:14px;height:14px}.sprite-adminUser{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -14px;width:14px;height:14px}.sprite-adminUser2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px 0;width:14px;height:14px}.sprite-airplane{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -14px;width:14px;height:14px}.sprite-alarm{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -28px;width:14px;height:14px}.sprite-alert{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -28px;width:14px;height:14px}.sprite-alert2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -28px;width:14px;height:14px}.sprite-android{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px 0;width:14px;height:14px}.sprite-archive{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -14px;width:14px;height:14px}.sprite-arrowDown{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -28px;width:14px;height:14px}.sprite-arrowLeft{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -42px;width:14px;height:14px}.sprite-arrowRight{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -42px;width:14px;height:14px}.sprite-arrowUp{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -42px;width:14px;height:14px}.sprite-bag{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -42px;width:14px;height:14px}.sprite-baloons{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px 0;width:14px;height:14px}.sprite-bandaid{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -14px;width:14px;height:14px}.sprite-basket{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -28px;width:14px;height:14px}.sprite-basket2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -42px;width:14px;height:14px}.sprite-battery{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -56px;width:14px;height:14px}.sprite-batteryFull{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -56px;width:14px;height:14px}.sprite-bell{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -56px;width:14px;height:14px}.sprite-bell2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -56px;width:14px;height:14px}.sprite-bigBrush{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -56px;width:14px;height:14px}.sprite-blackberry{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px 0;width:14px;height:14px}.sprite-block{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -14px;width:14px;height:14px}.sprite-blocks{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -28px;width:14px;height:14px}.sprite-bluetooth{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -42px;width:14px;height:14px}.sprite-bluetooth2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -56px;width:14px;height:14px}.sprite-bluray{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -70px;width:14px;height:14px}.sprite-book{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -70px;width:14px;height:14px}.sprite-bookLarge{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -70px;width:14px;height:14px}.sprite-books{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -70px;width:14px;height:14px}.sprite-bright{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -70px;width:14px;height:14px}.sprite-bubbles{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -70px;width:14px;height:14px}.sprite-bubbles2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px 0;width:14px;height:14px}.sprite-building{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -14px;width:14px;height:14px}.sprite-bullsEye{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -28px;width:14px;height:14px}.sprite-buzz{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -42px;width:14px;height:14px}.sprite-calc{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -56px;width:14px;height:14px}.sprite-camera{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -70px;width:14px;height:14px}.sprite-camera2{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -84px;width:14px;height:14px}.sprite-car{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -84px;width:14px;height:14px}.sprite-cart{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -84px;width:14px;height:14px}.sprite-cart2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -84px;width:14px;height:14px}.sprite-cart3{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -84px;width:14px;height:14px}.sprite-cart4{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -84px;width:14px;height:14px}.sprite-cashRegister{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -84px;width:14px;height:14px}.sprite-cassette{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px 0;width:14px;height:14px}.sprite-cat{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -14px;width:14px;height:14px}.sprite-cd{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -28px;width:14px;height:14px}.sprite-chair{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -42px;width:14px;height:14px}.sprite-chart{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -56px;width:14px;height:14px}.sprite-chart2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -70px;width:14px;height:14px}.sprite-chart3{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -84px;width:14px;height:14px}.sprite-chart4{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -98px;width:14px;height:14px}.sprite-chart5{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -98px;width:14px;height:14px}.sprite-chart6{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -98px;width:14px;height:14px}.sprite-chart7{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -98px;width:14px;height:14px}.sprite-chart8{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -98px;width:14px;height:14px}.sprite-check{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -98px;width:14px;height:14px}.sprite-chemical{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -98px;width:14px;height:14px}.sprite-chrome{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -98px;width:14px;height:14px}.sprite-clipboard{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px 0;width:14px;height:14px}.sprite-clock{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -14px;width:14px;height:14px}.sprite-close{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -28px;width:14px;height:14px}.sprite-cloud{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -42px;width:14px;height:14px}.sprite-cloudDownload{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -56px;width:14px;height:14px}.sprite-cloudUpload{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -70px;width:14px;height:14px}.sprite-cog{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -84px;width:14px;height:14px}.sprite-cog2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -98px;width:14px;height:14px}.sprite-cog3{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -112px;width:14px;height:14px}.sprite-cog4{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -112px;width:14px;height:14px}.sprite-companies{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -112px;width:14px;height:14px}.sprite-computer{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -112px;width:14px;height:14px}.sprite-coverflow{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -112px;width:14px;height:14px}.sprite-create{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -112px;width:14px;height:14px}.sprite-cup{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -112px;width:14px;height:14px}.sprite-cut{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -112px;width:14px;height:14px}.sprite-dayCalendar{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -112px;width:14px;height:14px}.sprite-delicious{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px 0;width:14px;height:14px}.sprite-denied{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -14px;width:14px;height:14px}.sprite-dialog{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -28px;width:14px;height:14px}.sprite-digg{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -42px;width:14px;height:14px}.sprite-digg2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -56px;width:14px;height:14px}.sprite-doc{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -70px;width:14px;height:14px}.sprite-docs{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -84px;width:14px;height:14px}.sprite-download{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -98px;width:14px;height:14px}.sprite-download2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -112px;width:14px;height:14px}.sprite-download3{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -126px;width:14px;height:14px}.sprite-dribbble{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -126px;width:14px;height:14px}.sprite-dribbble2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -126px;width:14px;height:14px}.sprite-drive{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -126px;width:14px;height:14px}.sprite-dropbox{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -126px;width:14px;height:14px}.sprite-dropper{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -126px;width:14px;height:14px}.sprite-drupal{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -126px;width:14px;height:14px}.sprite-dvd{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -126px;width:14px;height:14px}.sprite-electricity{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -126px;width:14px;height:14px}.sprite-electroPlug{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -126px;width:14px;height:14px}.sprite-excelDoc{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px 0;width:14px;height:14px}.sprite-exit{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -14px;width:14px;height:14px}.sprite-expengine{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -28px;width:14px;height:14px}.sprite-expose{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -42px;width:14px;height:14px}.sprite-facebook{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -56px;width:14px;height:14px}.sprite-fax{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -70px;width:14px;height:14px}.sprite-femaleContour{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -84px;width:14px;height:14px}.sprite-femaleSymbol{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -98px;width:14px;height:14px}.sprite-files{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -112px;width:14px;height:14px}.sprite-filmCamera{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -126px;width:14px;height:14px}.sprite-filmStrip{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -140px;width:14px;height:14px}.sprite-filmStrip2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -140px;width:14px;height:14px}.sprite-firefox{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -140px;width:14px;height:14px}.sprite-flag{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -140px;width:14px;height:14px}.sprite-flag2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -140px;width:14px;height:14px}.sprite-flagFinished{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -140px;width:14px;height:14px}.sprite-folder{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -140px;width:14px;height:14px}.sprite-footprints{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -140px;width:14px;height:14px}.sprite-fountainPen{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -140px;width:14px;height:14px}.sprite-frames{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -140px;width:14px;height:14px}.sprite-full{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -140px;width:14px;height:14px}.sprite-full2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px 0;width:14px;height:14px}.sprite-fullscreen{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -14px;width:14px;height:14px}.sprite-globe{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -28px;width:14px;height:14px}.sprite-globe2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -42px;width:14px;height:14px}.sprite-gmaps{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -56px;width:14px;height:14px}.sprite-goBack{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -70px;width:14px;height:14px}.sprite-goFull{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -84px;width:14px;height:14px}.sprite-graph{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -98px;width:14px;height:14px}.sprite-hd{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -112px;width:14px;height:14px}.sprite-hd2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -126px;width:14px;height:14px}.sprite-hd3{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -140px;width:14px;height:14px}.sprite-headphones{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -154px;width:14px;height:14px}.sprite-heart{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -154px;width:14px;height:14px}.sprite-help{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -154px;width:14px;height:14px}.sprite-home{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -154px;width:14px;height:14px}.sprite-home2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -154px;width:14px;height:14px}.sprite-icecream{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -154px;width:14px;height:14px}.sprite-ichat{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -154px;width:14px;height:14px}.sprite-image{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -154px;width:14px;height:14px}.sprite-image2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -154px;width:14px;height:14px}.sprite-imageList{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -154px;width:14px;height:14px}.sprite-images{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -154px;width:14px;height:14px}.sprite-images2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -154px;width:14px;height:14px}.sprite-imagesList{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px 0;width:14px;height:14px}.sprite-inbox{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -14px;width:14px;height:14px}.sprite-inbox2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -28px;width:14px;height:14px}.sprite-incoming{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -42px;width:14px;height:14px}.sprite-info{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -56px;width:14px;height:14px}.sprite-ipad{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -70px;width:14px;height:14px}.sprite-iphone{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -84px;width:14px;height:14px}.sprite-ipodClassic{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -98px;width:14px;height:14px}.sprite-ipodNano{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -112px;width:14px;height:14px}.sprite-joomla{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -126px;width:14px;height:14px}.sprite-key{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -140px;width:14px;height:14px}.sprite-ladyPurse{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -154px;width:14px;height:14px}.sprite-lamp{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -168px;width:14px;height:14px}.sprite-laptop{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -168px;width:14px;height:14px}.sprite-lastFM{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -168px;width:14px;height:14px}.sprite-lemonadeStand{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -168px;width:14px;height:14px}.sprite-lightBulb{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -168px;width:14px;height:14px}.sprite-like{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -168px;width:14px;height:14px}.sprite-link{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -168px;width:14px;height:14px}.sprite-link2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -168px;width:14px;height:14px}.sprite-linux{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -168px;width:14px;height:14px}.sprite-list{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -168px;width:14px;height:14px}.sprite-loading{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -168px;width:14px;height:14px}.sprite-locked{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -168px;width:14px;height:14px}.sprite-locked2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -168px;width:14px;height:14px}.sprite-logoff{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px 0;width:14px;height:14px}.sprite-macos{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -14px;width:14px;height:14px}.sprite-magicMouse{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -28px;width:14px;height:14px}.sprite-magnify{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -42px;width:14px;height:14px}.sprite-mail{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -56px;width:14px;height:14px}.sprite-maleContour{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -70px;width:14px;height:14px}.sprite-maleSymbol{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -84px;width:14px;height:14px}.sprite-map{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -98px;width:14px;height:14px}.sprite-medicalCase{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -112px;width:14px;height:14px}.sprite-megaphone{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -126px;width:14px;height:14px}.sprite-microphone{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -140px;width:14px;height:14px}.sprite-mightyMouse{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -154px;width:14px;height:14px}.sprite-mobile{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -168px;width:14px;height:14px}.sprite-mobyPicture{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -182px;width:14px;height:14px}.sprite-money{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -182px;width:14px;height:14px}.sprite-money2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -182px;width:14px;height:14px}.sprite-monitor{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -182px;width:14px;height:14px}.sprite-monthCalendar{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -182px;width:14px;height:14px}.sprite-mouse{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -182px;width:14px;height:14px}.sprite-music{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -182px;width:14px;height:14px}.sprite-myspace{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -182px;width:14px;height:14px}.sprite-notebook{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -182px;width:14px;height:14px}.sprite-outgoing{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -182px;width:14px;height:14px}.sprite-pacman{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -182px;width:14px;height:14px}.sprite-paintBrush{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -182px;width:14px;height:14px}.sprite-pants{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -182px;width:14px;height:14px}.sprite-paperclip{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -182px;width:14px;height:14px}.sprite-paypal{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px 0;width:14px;height:14px}.sprite-paypal2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -14px;width:14px;height:14px}.sprite-paypal3{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -28px;width:14px;height:14px}.sprite-pdfDoc{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -42px;width:14px;height:14px}.sprite-pencil{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -56px;width:14px;height:14px}.sprite-phone{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -70px;width:14px;height:14px}.sprite-phone2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -84px;width:14px;height:14px}.sprite-phone3{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -98px;width:14px;height:14px}.sprite-photos{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -112px;width:14px;height:14px}.sprite-piggyBank{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -126px;width:14px;height:14px}.sprite-pin{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -140px;width:14px;height:14px}.sprite-planeSuitcase{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -154px;width:14px;height:14px}.sprite-play{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -168px;width:14px;height:14px}.sprite-play2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -182px;width:14px;height:14px}.sprite-plixi{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -196px;width:14px;height:14px}.sprite-podium{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -196px;width:14px;height:14px}.sprite-postcard{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -196px;width:14px;height:14px}.sprite-power{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -196px;width:14px;height:14px}.sprite-powerBattery{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -196px;width:14px;height:14px}.sprite-ppDoc{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -196px;width:14px;height:14px}.sprite-presentation{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -196px;width:14px;height:14px}.sprite-preview{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -196px;width:14px;height:14px}.sprite-priceTag{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -196px;width:14px;height:14px}.sprite-priceTags{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -196px;width:14px;height:14px}.sprite-printer{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -196px;width:14px;height:14px}.sprite-radio{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -196px;width:14px;height:14px}.sprite-record{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -196px;width:14px;height:14px}.sprite-recycle{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -196px;width:14px;height:14px}.sprite-refresh{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -196px;width:14px;height:14px}.sprite-refresh2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px 0;width:14px;height:14px}.sprite-refresh3{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -14px;width:14px;height:14px}.sprite-refresh4{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -28px;width:14px;height:14px}.sprite-repeat{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -42px;width:14px;height:14px}.sprite-robot{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -56px;width:14px;height:14px}.sprite-rss{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -70px;width:14px;height:14px}.sprite-ruler{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -84px;width:14px;height:14px}.sprite-ruler2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -98px;width:14px;height:14px}.sprite-runningMan{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -112px;width:14px;height:14px}.sprite-safari{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -126px;width:14px;height:14px}.sprite-scanLabel{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -140px;width:14px;height:14px}.sprite-sd{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -154px;width:14px;height:14px}.sprite-sd2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -168px;width:14px;height:14px}.sprite-sd3{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -182px;width:14px;height:14px}.sprite-settings{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -196px;width:14px;height:14px}.sprite-settings2{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -210px;width:14px;height:14px}.sprite-shirt{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -210px;width:14px;height:14px}.sprite-shoppingBag{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -210px;width:14px;height:14px}.sprite-shuffle{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -210px;width:14px;height:14px}.sprite-signPost{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -210px;width:14px;height:14px}.sprite-signal{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -210px;width:14px;height:14px}.sprite-skype{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -210px;width:14px;height:14px}.sprite-smallBrush{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -210px;width:14px;height:14px}.sprite-socks{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -210px;width:14px;height:14px}.sprite-sound{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -210px;width:14px;height:14px}.sprite-speech{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -210px;width:14px;height:14px}.sprite-speech2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -210px;width:14px;height:14px}.sprite-star{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -210px;width:14px;height:14px}.sprite-stats{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -210px;width:14px;height:14px}.sprite-stop{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -210px;width:14px;height:14px}.sprite-stopWatch{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -210px;width:14px;height:14px}.sprite-strategy{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px 0;width:14px;height:14px}.sprite-strategy2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -14px;width:14px;height:14px}.sprite-stumble{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -28px;width:14px;height:14px}.sprite-suitcase{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -42px;width:14px;height:14px}.sprite-switcher{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -56px;width:14px;height:14px}.sprite-table{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -70px;width:14px;height:14px}.sprite-tag{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -84px;width:14px;height:14px}.sprite-tags{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -98px;width:14px;height:14px}.sprite-timer{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -112px;width:14px;height:14px}.sprite-transfer{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -126px;width:14px;height:14px}.sprite-trash{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -140px;width:14px;height:14px}.sprite-travelSuitcase{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -154px;width:14px;height:14px}.sprite-tree{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -168px;width:14px;height:14px}.sprite-trolly{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -182px;width:14px;height:14px}.sprite-truck{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -196px;width:14px;height:14px}.sprite-tumbler{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -210px;width:14px;height:14px}.sprite-tv{background-image:url(../sprites/dark-icons-sprite.png);background-position:0 -224px;width:14px;height:14px}.sprite-twitter{background-image:url(../sprites/dark-icons-sprite.png);background-position:-14px -224px;width:14px;height:14px}.sprite-twitter2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-28px -224px;width:14px;height:14px}.sprite-umbrella{background-image:url(../sprites/dark-icons-sprite.png);background-position:-42px -224px;width:14px;height:14px}.sprite-underConstruction{background-image:url(../sprites/dark-icons-sprite.png);background-position:-56px -224px;width:14px;height:14px}.sprite-unlocked{background-image:url(../sprites/dark-icons-sprite.png);background-position:-70px -224px;width:14px;height:14px}.sprite-upload{background-image:url(../sprites/dark-icons-sprite.png);background-position:-84px -224px;width:14px;height:14px}.sprite-user{background-image:url(../sprites/dark-icons-sprite.png);background-position:-98px -224px;width:14px;height:14px}.sprite-user2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-112px -224px;width:14px;height:14px}.sprite-userComment{background-image:url(../sprites/dark-icons-sprite.png);background-position:-126px -224px;width:14px;height:14px}.sprite-users{background-image:url(../sprites/dark-icons-sprite.png);background-position:-140px -224px;width:14px;height:14px}.sprite-users2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-154px -224px;width:14px;height:14px}.sprite-vault{background-image:url(../sprites/dark-icons-sprite.png);background-position:-168px -224px;width:14px;height:14px}.sprite-vcard{background-image:url(../sprites/dark-icons-sprite.png);background-position:-182px -224px;width:14px;height:14px}.sprite-view{background-image:url(../sprites/dark-icons-sprite.png);background-position:-196px -224px;width:14px;height:14px}.sprite-vimeo{background-image:url(../sprites/dark-icons-sprite.png);background-position:-210px -224px;width:14px;height:14px}.sprite-vimeo2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-224px -224px;width:14px;height:14px}.sprite-walkingMan{background-image:url(../sprites/dark-icons-sprite.png);background-position:-238px 0;width:14px;height:14px}.sprite-wifi{background-image:url(../sprites/dark-icons-sprite.png);background-position:-238px -14px;width:14px;height:14px}.sprite-wifi2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-238px -28px;width:14px;height:14px}.sprite-windows{background-image:url(../sprites/dark-icons-sprite.png);background-position:-238px -42px;width:14px;height:14px}.sprite-wordDoc{background-image:url(../sprites/dark-icons-sprite.png);background-position:-238px -56px;width:14px;height:14px}.sprite-wordpress{background-image:url(../sprites/dark-icons-sprite.png);background-position:-238px -70px;width:14px;height:14px}.sprite-wordpress2{background-image:url(../sprites/dark-icons-sprite.png);background-position:-238px -84px;width:14px;height:14px}.sprite-youtube{background-image:url(../sprites/dark-icons-sprite.png);background-position:-238px -98px;width:14px;height:14px}.sprite-zip{background-image:url(../sprites/dark-icons-sprite.png);background-position:-238px -112px;width:14px;height:14px}.sprite-zipFiles{background-image:url(../sprites/dark-icons-sprite.png);background-position:-238px -126px;width:14px;height:14px}.sprite-23-basket2{background-image:url(../sprites/dark-icons-23-sprite.png);background-position:0 0;width:23px;height:23px}.sprite-23-dialog{background-image:url(../sprites/dark-icons-23-sprite.png);background-position:-23px 0;width:23px;height:23px}.sprite-23-home{background-image:url(../sprites/dark-icons-23-sprite.png);background-position:0 -23px;width:23px;height:23px}.sprite-23-money{background-image:url(../sprites/dark-icons-23-sprite.png);background-position:-23px -23px;width:23px;height:23px}.sprite-23-speech{background-image:url(../sprites/dark-icons-23-sprite.png);background-position:-46px 0;width:23px;height:23px}.sprite-23-user{background-image:url(../sprites/dark-icons-23-sprite.png);background-position:-46px -23px;width:23px;height:23px}.sprite-topnav-contactAdmin{background-image:url(../sprites/topnav-sprite.png);background-position:-22px 0;width:11px;height:10px}.sprite-topnav-help{background-image:url(../sprites/topnav-sprite.png);background-position:0 -22px;width:10px;height:10px}.sprite-topnav-logout{background-image:url(../sprites/topnav-sprite.png);background-position:0 0;width:11px;height:11px}.sprite-topnav-mainWebsite{background-image:url(../sprites/topnav-sprite.png);background-position:-10px -22px;width:10px;height:10px}.sprite-topnav-messages{background-image:url(../sprites/topnav-sprite.png);background-position:-11px 0;width:11px;height:11px}.sprite-topnav-profile{background-image:url(../sprites/topnav-sprite.png);background-position:0 -11px;width:11px;height:11px}.sprite-topnav-register{background-image:url(../sprites/topnav-sprite.png);background-position:-20px -22px;width:10px;height:10px}.sprite-topnav-settings{background-image:url(../sprites/topnav-sprite.png);background-position:-22px -10px;width:10px;height:11px}.sprite-topnav-tasks{background-image:url(../sprites/topnav-sprite.png);background-position:-11px -11px;width:11px;height:11px}.ui-helper-hidden{display:none}.ui-helper-hidden-accessible{position:absolute;left:-99999999px}.ui-helper-reset{margin:0;padding:0;border:0;outline:0;line-height:1.3;text-decoration:none;font-size:100%;list-style:none}.ui-helper-clearfix:after{content:".";display:block;height:0;clear:both;visibility:hidden}.ui-helper-clearfix{display:inline-block}* html .ui-helper-clearfix{height:1%}.ui-helper-clearfix{display:block}.ui-helper-zfix{width:100%;height:100%;top:0;left:0;position:absolute;opacity:0;filter:Alpha(Opacity=0)}.ui-state-disabled{cursor:default!important}.ui-icon{display:block;text-indent:-99999px;overflow:hidden;background-repeat:no-repeat}.ui-widget-overlay{position:absolute;top:0;left:0;width:100%;height:100%}.ui-widget{font-size:12px}.ui-widget .ui-widget{font-size:1em}.ui-widget button,.ui-widget input,.ui-widget select,.ui-widget textarea{font-family:Verdana,Arial,sans-serif;font-size:1em}.ui-widget-content a{color:#222}.ui-widget-header{font-weight:700}.ui-widget-header a{color:#222}.ui-state-default,.ui-widget-content .ui-state-default,.ui-widget-header .ui-state-default{border-left:1px solid #d5d5d5;font-weight:400;border-bottom:1px solid #d5d5d5}th.ui-state-default:first-child{border-left:none}.ui-state-default a,.ui-state-default a:link,.ui-state-default a:visited{color:#555;text-decoration:none}.ui-state-focus,.ui-state-hover,.ui-widget-content .ui-state-focus,.ui-widget-content .ui-state-hover,.ui-widget-header .ui-state-focus,.ui-widget-header .ui-state-hover{background:#fafafa;font-weight:400;color:#212121}.ui-state-hover a,.ui-state-hover a:hover{color:#797979;text-decoration:none}.ui-state-active,.ui-widget-content .ui-state-active,.ui-widget-header .ui-state-active{background:#fafafa;font-weight:400;color:#797979}.ui-state-active a,.ui-state-active a:link,.ui-state-active a:visited{color:#797979;text-decoration:none}.ui-widget :active{outline:0}.ui-state-highlight a,.ui-widget-content .ui-state-highlight a,.ui-widget-header .ui-state-highlight a{color:#363636}.ui-state-error,.ui-widget-content .ui-state-error,.ui-widget-header .ui-state-error{border:1px solid #cd0a0a;background:#fef1ec url(../images/jquery_ui/ui-bg_glass_95_fef1ec_1x400.png) 50% 50% repeat-x;color:#cd0a0a}.ui-state-error a,.ui-widget-content .ui-state-error a,.ui-widget-header .ui-state-error a{color:#cd0a0a}.ui-state-error-text,.ui-widget-content .ui-state-error-text,.ui-widget-header .ui-state-error-text{color:#cd0a0a}.ui-priority-primary,.ui-widget-content .ui-priority-primary,.ui-widget-header .ui-priority-primary{font-weight:700}.ui-priority-secondary,.ui-widget-content .ui-priority-secondary,.ui-widget-header .ui-priority-secondary{opacity:.7;filter:Alpha(Opacity=70);font-weight:400}.ui-state-disabled,.ui-widget-content .ui-state-disabled,.ui-widget-header .ui-state-disabled{opacity:.35;filter:Alpha(Opacity=35);background-image:none}.ui-icon{width:16px;height:16px;background-image:url(../images/jquery_ui/ui-icons_222222_256x240.png)}.ui-widget-content .ui-icon{background-image:url(../images/jquery_ui/ui-icons_222222_256x240.png)}.ui-widget-header .ui-icon{background-image:url(../images/jquery_ui/ui-icons_222222_256x240.png)}.ui-state-default .ui-icon{background-image:url(../images/jquery_ui/ui-icons_888888_256x240.png)}.ui-state-focus .ui-icon,.ui-state-hover .ui-icon{background-image:url(../images/jquery_ui/ui-icons_454545_256x240.png)}.ui-state-active .ui-icon{background-image:url(../images/jquery_ui/ui-icons_454545_256x240.png)}.ui-state-highlight .ui-icon{background-image:url(../images/jquery_ui/ui-icons_2e83ff_256x240.png)}.ui-state-error .ui-icon,.ui-state-error-text .ui-icon{background-image:url(../images/jquery_ui/ui-icons_cd0a0a_256x240.png)}.ui-icon-carat-1-n{background-position:0 0}.ui-icon-carat-1-ne{background-position:-16px 0}.ui-icon-carat-1-e{background-position:-32px 0}.ui-icon-carat-1-se{background-position:-48px 0}.ui-icon-carat-1-s{background-position:-64px 0}.ui-icon-carat-1-sw{background-position:-80px 0}.ui-icon-carat-1-w{background-position:-96px 0}.ui-icon-carat-1-nw{background-position:-112px 0}.ui-icon-carat-2-n-s{background-position:-128px 0}.ui-icon-carat-2-e-w{background-position:-144px 0}.ui-icon-triangle-1-n{background-position:0 -16px}.ui-icon-triangle-1-ne{background-position:-16px -16px}.ui-icon-triangle-1-e{background-position:-32px -16px}.ui-icon-triangle-1-se{background-position:-48px -16px}.ui-icon-triangle-1-s{background-position:-64px -16px}.ui-icon-triangle-1-sw{background-position:-80px -16px}.ui-icon-triangle-1-w{background-position:-96px -16px}.ui-icon-triangle-1-nw{background-position:-112px -16px}.ui-icon-triangle-2-n-s{background-position:-128px -16px}.ui-icon-triangle-2-e-w{background-position:-144px -16px}.ui-icon-arrow-1-n{background-position:0 -32px}.ui-icon-arrow-1-ne{background-position:-16px -32px}.ui-icon-arrow-1-e{background-position:-32px -32px}.ui-icon-arrow-1-se{background-position:-48px -32px}.ui-icon-arrow-1-s{background-position:-64px -32px}.ui-icon-arrow-1-sw{background-position:-80px -32px}.ui-icon-arrow-1-w{background-position:-96px -32px}.ui-icon-arrow-1-nw{background-position:-112px -32px}.ui-icon-arrow-2-n-s{background-position:-128px -32px}.ui-icon-arrow-2-ne-sw{background-position:-144px -32px}.ui-icon-arrow-2-e-w{background-position:-160px -32px}.ui-icon-arrow-2-se-nw{background-position:-176px -32px}.ui-icon-arrowstop-1-n{background-position:-192px -32px}.ui-icon-arrowstop-1-e{background-position:-208px -32px}.ui-icon-arrowstop-1-s{background-position:-224px -32px}.ui-icon-arrowstop-1-w{background-position:-240px -32px}.ui-icon-arrowthick-1-n{background-position:0 -48px}.ui-icon-arrowthick-1-ne{background-position:-16px -48px}.ui-icon-arrowthick-1-e{background-position:-32px -48px}.ui-icon-arrowthick-1-se{background-position:-48px -48px}.ui-icon-arrowthick-1-s{background-position:-64px -48px}.ui-icon-arrowthick-1-sw{background-position:-80px -48px}.ui-icon-arrowthick-1-w{background-position:-96px -48px}.ui-icon-arrowthick-1-nw{background-position:-112px -48px}.ui-icon-arrowthick-2-n-s{background-position:-128px -48px}.ui-icon-arrowthick-2-ne-sw{background-position:-144px -48px}.ui-icon-arrowthick-2-e-w{background-position:-160px -48px}.ui-icon-arrowthick-2-se-nw{background-position:-176px -48px}.ui-icon-arrowthickstop-1-n{background-position:-192px -48px}.ui-icon-arrowthickstop-1-e{background-position:-208px -48px}.ui-icon-arrowthickstop-1-s{background-position:-224px -48px}.ui-icon-arrowthickstop-1-w{background-position:-240px -48px}.ui-icon-arrowreturnthick-1-w{background-position:0 -64px}.ui-icon-arrowreturnthick-1-n{background-position:-16px -64px}.ui-icon-arrowreturnthick-1-e{background-position:-32px -64px}.ui-icon-arrowreturnthick-1-s{background-position:-48px -64px}.ui-icon-arrowreturn-1-w{background-position:-64px -64px}.ui-icon-arrowreturn-1-n{background-position:-80px -64px}.ui-icon-arrowreturn-1-e{background-position:-96px -64px}.ui-icon-arrowreturn-1-s{background-position:-112px -64px}.ui-icon-arrowrefresh-1-w{background-position:-128px -64px}.ui-icon-arrowrefresh-1-n{background-position:-144px -64px}.ui-icon-arrowrefresh-1-e{background-position:-160px -64px}.ui-icon-arrowrefresh-1-s{background-position:-176px -64px}.ui-icon-arrow-4{background-position:0 -80px}.ui-icon-arrow-4-diag{background-position:-16px -80px}.ui-icon-extlink{background-position:-32px -80px}.ui-icon-newwin{background-position:-48px -80px}.ui-icon-refresh{background-position:-64px -80px}.ui-icon-shuffle{background-position:-80px -80px}.ui-icon-transfer-e-w{background-position:-96px -80px}.ui-icon-transferthick-e-w{background-position:-112px -80px}.ui-icon-folder-collapsed{background-position:0 -96px}.ui-icon-folder-open{background-position:-16px -96px}.ui-icon-document{background-position:-32px -96px}.ui-icon-document-b{background-position:-48px -96px}.ui-icon-note{background-position:-64px -96px}.ui-icon-mail-closed{background-position:-80px -96px}.ui-icon-mail-open{background-position:-96px -96px}.ui-icon-suitcase{background-position:-112px -96px}.ui-icon-comment{background-position:-128px -96px}.ui-icon-person{background-position:-144px -96px}.ui-icon-print{background-position:-160px -96px}.ui-icon-trash{background-position:-176px -96px}.ui-icon-locked{background-position:-192px -96px}.ui-icon-unlocked{background-position:-208px -96px}.ui-icon-bookmark{background-position:-224px -96px}.ui-icon-tag{background-position:-240px -96px}.ui-icon-home{background-position:0 -112px}.ui-icon-flag{background-position:-16px -112px}.ui-icon-calendar{background-position:-32px -112px}.ui-icon-cart{background-position:-48px -112px}.ui-icon-pencil{background-position:-64px -112px}.ui-icon-clock{background-position:-80px -112px}.ui-icon-disk{background-position:-96px -112px}.ui-icon-calculator{background-position:-112px -112px}.ui-icon-zoomin{background-position:-128px -112px}.ui-icon-zoomout{background-position:-144px -112px}.ui-icon-search{background-position:-160px -112px}.ui-icon-wrench{background-position:-176px -112px}.ui-icon-gear{background-position:-192px -112px}.ui-icon-heart{background-position:-208px -112px}.ui-icon-star{background-position:-224px -112px}.ui-icon-link{background-position:-240px -112px}.ui-icon-cancel{background-position:0 -128px}.ui-icon-plus{background-position:-16px -128px}.ui-icon-plusthick{background-position:-32px -128px}.ui-icon-minus{background-position:-48px -128px}.ui-icon-minusthick{background-position:-64px -128px}.ui-icon-close{background-position:-80px -128px}.ui-icon-closethick{background-position:-96px -128px}.ui-icon-key{background-position:-112px -128px}.ui-icon-lightbulb{background-position:-128px -128px}.ui-icon-scissors{background-position:-144px -128px}.ui-icon-clipboard{background-position:-160px -128px}.ui-icon-copy{background-position:-176px -128px}.ui-icon-contact{background-position:-192px -128px}.ui-icon-image{background-position:-208px -128px}.ui-icon-video{background-position:-224px -128px}.ui-icon-script{background-position:-240px -128px}.ui-icon-alert{background-position:0 -144px}.ui-icon-info{background-position:-16px -144px}.ui-icon-notice{background-position:-32px -144px}.ui-icon-help{background-position:-48px -144px}.ui-icon-check{background-position:-64px -144px}.ui-icon-bullet{background-position:-80px -144px}.ui-icon-radio-off{background-position:-96px -144px}.ui-icon-radio-on{background-position:-112px -144px}.ui-icon-pin-w{background-position:-128px -144px}.ui-icon-pin-s{background-position:-144px -144px}.ui-icon-play{background-position:0 -160px}.ui-icon-pause{background-position:-16px -160px}.ui-icon-seek-next{background-position:-32px -160px}.ui-icon-seek-prev{background-position:-48px -160px}.ui-icon-seek-end{background-position:-64px -160px}.ui-icon-seek-start{background-position:-80px -160px}.ui-icon-seek-first{background-position:-80px -160px}.ui-icon-stop{background-position:-96px -160px}.ui-icon-eject{background-position:-112px -160px}.ui-icon-volume-off{background-position:-128px -160px}.ui-icon-volume-on{background-position:-144px -160px}.ui-icon-power{background-position:0 -176px}.ui-icon-signal-diag{background-position:-16px -176px}.ui-icon-signal{background-position:-32px -176px}.ui-icon-battery-0{background-position:-48px -176px}.ui-icon-battery-1{background-position:-64px -176px}.ui-icon-battery-2{background-position:-80px -176px}.ui-icon-battery-3{background-position:-96px -176px}.ui-icon-circle-plus{background-position:0 -192px}.ui-icon-circle-minus{background-position:-16px -192px}.ui-icon-circle-close{background-position:-32px -192px}.ui-icon-circle-triangle-e{background-position:-48px -192px}.ui-icon-circle-triangle-s{background-position:-64px -192px}.ui-icon-circle-triangle-w{background-position:-80px -192px}.ui-icon-circle-triangle-n{background-position:-96px -192px}.ui-icon-circle-arrow-e{background-position:-112px -192px}.ui-icon-circle-arrow-s{background-position:-128px -192px}.ui-icon-circle-arrow-w{background-position:-144px -192px}.ui-icon-circle-arrow-n{background-position:-160px -192px}.ui-icon-circle-zoomin{background-position:-176px -192px}.ui-icon-circle-zoomout{background-position:-192px -192px}.ui-icon-circle-check{background-position:-208px -192px}.ui-icon-circlesmall-plus{background-position:0 -208px}.ui-icon-circlesmall-minus{background-position:-16px -208px}.ui-icon-circlesmall-close{background-position:-32px -208px}.ui-icon-squaresmall-plus{background-position:-48px -208px}.ui-icon-squaresmall-minus{background-position:-64px -208px}.ui-icon-squaresmall-close{background-position:-80px -208px}.ui-icon-grip-dotted-vertical{background-position:0 -224px}.ui-icon-grip-dotted-horizontal{background-position:-16px -224px}.ui-icon-grip-solid-vertical{background-position:-32px -224px}.ui-icon-grip-solid-horizontal{background-position:-48px -224px}.ui-icon-gripsmall-diagonal-se{background-position:-64px -224px}.ui-icon-grip-diagonal-se{background-position:-80px -224px}.ui-corner-tl{-moz-border-radius-topleft:2px;-webkit-border-top-left-radius:2px;border-top-left-radius:2px}.ui-corner-tr{-moz-border-radius-topright:2px;-webkit-border-top-right-radius:2px;border-top-right-radius:2px}.ui-corner-bl{-moz-border-radius-bottomleft:2px;-webkit-border-bottom-left-radius:2px;border-bottom-left-radius:2px}.ui-corner-br{-moz-border-radius-bottomright:2px;-webkit-border-bottom-right-radius:2px;border-bottom-right-radius:2px}.ui-corner-top{-moz-border-radius-topleft:2px;-webkit-border-top-left-radius:2px;border-top-left-radius:2px;-moz-border-radius-topright:2px;-webkit-border-top-right-radius:2px;border-top-right-radius:2px}.ui-corner-bottom{-moz-border-radius-bottomleft:2px;-webkit-border-bottom-left-radius:2px;border-bottom-left-radius:2px;-moz-border-radius-bottomright:2px;-webkit-border-bottom-right-radius:2px;border-bottom-right-radius:2px}.ui-corner-right{-moz-border-radius-topright:2px;-webkit-border-top-right-radius:2px;border-top-right-radius:2px;-moz-border-radius-bottomright:2px;-webkit-border-bottom-right-radius:2px;border-bottom-right-radius:2px}.ui-corner-left{-moz-border-radius-topleft:2px;-webkit-border-top-left-radius:2px;border-top-left-radius:2px;-moz-border-radius-bottomleft:2px;-webkit-border-bottom-left-radius:2px;border-bottom-left-radius:2px}.ui-corner-all{-moz-border-radius:2px;-webkit-border-radius:2px;border-radius:2px}.ui-widget-overlay{background:#aaa url(../images/jquery_ui/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x;opacity:.3;filter:Alpha(Opacity=30)}.ui-widget-shadow{margin:-8px 0 0 -8px;padding:8px;background:#aaa url(../images/jquery_ui/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x;opacity:.3;filter:Alpha(Opacity=30);-moz-border-radius:8px;-webkit-border-radius:8px;border-radius:8px}.ui-resizable{position:relative}.ui-resizable-handle{position:absolute;font-size:.1px;z-index:99999;display:block}.ui-resizable-autohide .ui-resizable-handle,.ui-resizable-disabled .ui-resizable-handle{display:none}.ui-resizable-n{cursor:n-resize;height:7px;width:100%;top:-5px;left:0}.ui-resizable-s{cursor:s-resize;height:7px;width:100%;bottom:-5px;left:0}.ui-resizable-e{cursor:e-resize;width:7px;right:-5px;top:0;height:100%}.ui-resizable-w{cursor:w-resize;width:7px;left:-5px;top:0;height:100%}.ui-resizable-se{cursor:se-resize;width:12px;height:12px;right:1px;bottom:1px}.ui-resizable-sw{cursor:sw-resize;width:9px;height:9px;left:-5px;bottom:-5px}.ui-resizable-nw{cursor:nw-resize;width:9px;height:9px;left:-5px;top:-5px}.ui-resizable-ne{cursor:ne-resize;width:9px;height:9px;right:-5px;top:-5px}.ui-selectable-helper{position:absolute;z-index:100;border:1px dotted #000}.ui-accordion{width:100%}.ui-accordion .ui-accordion-header{cursor:pointer;position:relative;margin-top:1px;zoom:1}.ui-accordion .ui-accordion-li-fix{display:inline}.ui-accordion .ui-accordion-header-active{border-bottom:0!important}.ui-accordion .ui-accordion-header a{display:block;font-size:1em;padding:.5em .5em .5em .7em}.ui-accordion-icons .ui-accordion-header a{padding-left:2.2em}.ui-accordion .ui-accordion-header .ui-icon{position:absolute;left:.5em;top:50%;margin-top:-8px}.ui-accordion .ui-accordion-content{padding:1em 2.2em;border-top:0;margin-top:-2px;position:relative;top:1px;margin-bottom:2px;overflow:auto;display:none;zoom:1}.ui-accordion .ui-accordion-content-active{display:block}.ui-autocomplete{position:absolute;cursor:default}* html .ui-autocomplete{width:1px}.ui-menu{list-style:none;padding:2px;margin:0;display:block;float:left}.ui-menu .ui-menu{margin-top:-3px}.ui-menu .ui-menu-item{margin:0;padding:0;zoom:1;float:left;clear:left;width:100%}.ui-menu .ui-menu-item a{text-decoration:none;display:block;padding:.2em .4em;line-height:1.5;zoom:1}.ui-menu .ui-menu-item a.ui-state-active,.ui-menu .ui-menu-item a.ui-state-hover{font-weight:400;margin:-1px}.ui-button{display:inline-block;position:relative;padding:0;margin-right:.1em;text-decoration:none!important;cursor:pointer;text-align:center;zoom:1;overflow:visible}.ui-button-icon-only{width:2.2em}button.ui-button-icon-only{width:2.4em}.ui-button-icons-only{width:3.4em}button.ui-button-icons-only{width:3.7em}.ui-button .ui-button-text{display:block;line-height:1.4}.ui-button-icon-only .ui-button-text,.ui-button-icons-only .ui-button-text{padding:.4em;text-indent:-9999999px}.ui-button-text-icon-primary .ui-button-text,.ui-button-text-icons .ui-button-text{padding:.4em 1em .4em 2.1em}.ui-button-text-icon-secondary .ui-button-text,.ui-button-text-icons .ui-button-text{padding:.4em 2.1em .4em 1em}.ui-button-text-icons .ui-button-text{padding-left:2.1em;padding-right:2.1em}input.ui-button{padding:.4em 1em}.ui-button-icon-only .ui-icon,.ui-button-icons-only .ui-icon,.ui-button-text-icon-primary .ui-icon,.ui-button-text-icon-secondary .ui-icon,.ui-button-text-icons .ui-icon{position:absolute;top:50%;margin-top:-8px}.ui-button-icon-only .ui-icon{left:50%;margin-left:-8px}.ui-button-icons-only .ui-button-icon-primary,.ui-button-text-icon-primary .ui-button-icon-primary,.ui-button-text-icons .ui-button-icon-primary{left:.5em}.ui-button-icons-only .ui-button-icon-secondary,.ui-button-text-icon-secondary .ui-button-icon-secondary,.ui-button-text-icons .ui-button-icon-secondary{right:.5em}.ui-button-icons-only .ui-button-icon-secondary,.ui-button-text-icons .ui-button-icon-secondary{right:.5em}.ui-buttonset{margin-right:5px}.ui-buttonset .ui-button{margin:0 3px;background:#fafafa;border:1px solid #d5d5d5;line-height:14px;font-size:11px}button.ui-button::-moz-focus-inner{border:0;padding:0}.ui-dialog{position:absolute;padding:.2em;width:300px;overflow:hidden}.ui-dialog .ui-dialog-titlebar{position:relative}.ui-dialog .ui-dialog-title{float:left;height:38px;font-size:16px;padding:0 12px 0 12px;line-height:38px}.ui-dialog .ui-dialog-titlebar-close{position:absolute;right:6px;top:50%;width:19px;margin:-10px 0 0 0;padding:1px;height:18px}.ui-dialog .ui-dialog-titlebar-close span{display:block;margin:1px}.ui-dialog .ui-dialog-titlebar-close:focus,.ui-dialog .ui-dialog-titlebar-close:hover{padding:1px;background:#fafafa}.ui-dialog .ui-dialog-content{position:relative;border:0;padding:.5em 1em;background:0 0;overflow:auto;zoom:1}.ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset{float:right}.ui-dialog .ui-dialog-buttonpane button{font-size:10px;font-weight:700;text-transform:uppercase;padding:3px 12px 4px 12px;cursor:pointer;font-family:Arial,Helvetica,sans-serif;border:1px solid #d5d5d5;color:#525252;margin:5px}.ui-dialog .ui-resizable-se{width:14px;height:14px;right:3px;bottom:3px}.ui-draggable .ui-dialog-titlebar{cursor:move}.ui-slider{position:relative;text-align:left}.ui-slider .ui-slider-handle{position:absolute;z-index:2;width:16px;height:16px;cursor:default;background:url(../images/ui/handle.png) no-repeat;border:none;cursor:pointer}.ui-slider .ui-slider-range{position:absolute;z-index:1;font-size:.7em;display:block;border:0;background:url(../images/ui/sliderOverlay.png) repeat-x;-moz-border-radius:4px;-webkit-border-radius:4px;-khtml-border-radius:4px;border-radius:4px}.ui-slider-horizontal{height:6px;background:url(../images/ui/sliderBg.png) repeat-x;clear:both;margin-top:10px}.ui-slider-horizontal .ui-slider-handle{top:-5px;margin-left:-.6em}.ui-slider-horizontal .ui-slider-range{top:0;height:100%}.ui-slider-horizontal .ui-slider-range-min{left:0}.ui-slider-horizontal .ui-slider-range-max{right:0}.ui-slider-vertical{width:6px;height:100px;background:url(../images/ui/sliderBgVert.png) repeat-y}.ui-slider-vertical .ui-slider-handle{left:-5px;margin-left:0;margin-bottom:-.6em}.ui-slider-vertical .ui-slider-range{left:0;width:100%;background:url(../images/ui/sliderOverlayVert.png) repeat-y}.ui-slider-vertical .ui-slider-range-min{bottom:0}.ui-slider-vertical .ui-slider-range-max{top:0}.ui-tabs{position:relative;padding:.2em;zoom:1}.ui-tabs .ui-tabs-nav{margin:0;padding:.2em .2em 0}.ui-tabs .ui-tabs-nav li{list-style:none;float:left;position:relative;top:1px;margin:0 .2em 1px 0;border-bottom:0!important;padding:0;white-space:nowrap}.ui-tabs .ui-tabs-nav li a{float:left;padding:.5em 1em;text-decoration:none}.ui-tabs .ui-tabs-nav li.ui-tabs-selected{margin-bottom:0;padding-bottom:1px}.ui-tabs .ui-tabs-nav li.ui-state-disabled a,.ui-tabs .ui-tabs-nav li.ui-state-processing a,.ui-tabs .ui-tabs-nav li.ui-tabs-selected a{cursor:text}.ui-tabs .ui-tabs-nav li a,.ui-tabs.ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-selected a{cursor:pointer}.ui-tabs .ui-tabs-panel{display:block;border-width:0;padding:1em 1.4em;background:0 0}.ui-tabs .ui-tabs-hide{display:none!important}.datepicker{width:70px!important}.ui-datepicker{width:17em;padding:.2em .2em 0;border:1px solid #d5d5d5;background:#fafafa;margin-top:1px;z-index:3;display:none}.ui-datepicker-append{margin-left:10px}.ui-datepicker .ui-datepicker-header{position:relative;padding:.2em 0;border:1px solid #e7e7e7;background:url(../images/leftNavBg.png) repeat-x}.ui-datepicker .ui-datepicker-next,.ui-datepicker .ui-datepicker-prev{position:absolute;top:2px;width:1.8em;height:1.8em}.ui-datepicker .ui-datepicker-next-hover,.ui-datepicker .ui-datepicker-prev-hover{top:1px}.ui-datepicker .ui-datepicker-prev{left:2px}.ui-datepicker .ui-datepicker-next{right:2px}.ui-datepicker .ui-datepicker-prev-hover{left:1px}.ui-datepicker .ui-datepicker-next-hover{right:1px}.ui-datepicker .ui-datepicker-next span,.ui-datepicker .ui-datepicker-prev span{display:block;position:absolute;left:50%;margin-left:-8px;top:50%;margin-top:-8px}.ui-datepicker .ui-datepicker-title{margin:0 2.3em;line-height:1.8em;text-align:center}.ui-datepicker .ui-datepicker-title select{font-size:1em;margin:1px 0}.ui-datepicker select.ui-datepicker-month-year{width:100%}.ui-datepicker select.ui-datepicker-month,.ui-datepicker select.ui-datepicker-year{width:49%}.ui-datepicker table{width:100%;font-size:.9em;border-collapse:collapse;margin:0 0 .4em}.ui-datepicker table .ui-state-default{border:1px solid #d5d5d5}.ui-datepicker table tbody{font-size:11px}.ui-datepicker th{padding:.7em .3em;text-align:center;font-weight:700;border:0}.ui-datepicker td{border:0;padding:1px}.ui-datepicker td a,.ui-datepicker td span{display:block;padding:.2em;text-align:right;text-decoration:none}.ui-datepicker .ui-datepicker-buttonpane{background-image:none;margin:.7em 0 0 0;padding:0 .2em;border-left:0;border-right:0;border-bottom:0}.ui-datepicker .ui-datepicker-buttonpane button{float:right;margin:.5em .2em .4em;cursor:pointer;padding:.2em .6em .3em .6em;width:auto;overflow:visible}.ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current{float:left}.ui-datepicker.ui-datepicker-multi{width:auto}.ui-datepicker-multi .ui-datepicker-group{float:left}.ui-datepicker-multi .ui-datepicker-group table{width:95%;margin:0 auto .4em}.ui-datepicker-multi-2 .ui-datepicker-group{width:50%}.ui-datepicker-multi-3 .ui-datepicker-group{width:33.3%}.ui-datepicker-multi-4 .ui-datepicker-group{width:25%}.ui-datepicker-multi .ui-datepicker-group-last .ui-datepicker-header{border-left-width:0}.ui-datepicker-multi .ui-datepicker-group-middle .ui-datepicker-header{border-left-width:0}.ui-datepicker-multi .ui-datepicker-buttonpane{clear:left}.ui-datepicker-row-break{clear:both;width:100%}.ui-datepicker-rtl{direction:rtl}.ui-datepicker-rtl .ui-datepicker-prev{right:2px;left:auto}.ui-datepicker-rtl .ui-datepicker-next{left:2px;right:auto}.ui-datepicker-rtl .ui-datepicker-prev:hover{right:1px;left:auto}.ui-datepicker-rtl .ui-datepicker-next:hover{left:1px;right:auto}.ui-datepicker-rtl .ui-datepicker-buttonpane{clear:right}.ui-datepicker-rtl .ui-datepicker-buttonpane button{float:left}.ui-datepicker-rtl .ui-datepicker-buttonpane button.ui-datepicker-current{float:right}.ui-datepicker-rtl .ui-datepicker-group{float:right}.ui-datepicker-rtl .ui-datepicker-group-last .ui-datepicker-header{border-right-width:0;border-left-width:1px}.ui-datepicker-rtl .ui-datepicker-group-middle .ui-datepicker-header{border-right-width:0;border-left-width:1px}.ui-progressbar{height:16px;text-align:left;margin-top:5px;background:url(../images/ui/progress.png) repeat-x}.ui-progressbar .ui-progressbar-value{margin:0;height:100%;overflow:hidden;display:block;background:url(../images/ui/progressOverlay.png) repeat-x;border-right:1px solid #3c95d8}.pbar .ui-progressbar-value{display:block!important}.pbar{overflow:hidden;background:url(../images/ui/progress.png) repeat-x}.percent{position:relative;text-align:right;margin-bottom:5px;font-size:11px}.elapsed{position:relative;text-align:right;margin-top:5px;font-size:11px}.ui-autocomplete{position:absolute;cursor:default}* html .ui-autocomplete{width:1px}.ui-menu{list-style:none;padding:2px;margin:0;display:block;float:left;border:1px solid #3c4049;border-top:0;z-index:11}.ui-menu .ui-menu{margin-top:-3px}.ui-menu .ui-menu-item{margin:0;padding:0;zoom:1;float:left;clear:left;width:100%;background-color:#f5f5f5}.ui-menu .ui-menu-item a{text-decoration:none;display:block;line-height:1.5}.ui-menu .ui-menu-item a.ui-state-active,.ui-menu .ui-menu-item a.ui-state-hover{font-weight:700}.breadCrumbHolder.module{margin-top:0}.pagination{margin-top:40px;margin-bottom:40px}.mainForm input[type=email]{background:#fff;width:100%;border:1px solid #d5d5d5;padding:5px;font-size:11px;font-family:Arial,Helvetica,sans-serif;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;-ms-box-sizing:border-box;box-sizing:border-box}div.help{border-bottom:1px solid #e7e7e7;margin:10px 0 0;padding:10px 12px}div.help h3{font-size:1.5em;margin-bottom:5px}div.help blockquote{margin:5px 0;line-height:1.5em;padding:5px;border:0;text-align:left}.tableStatic thead th{padding:3px 0 2px 0;text-align:center;border-left:1px solid #d5d5d5;background:#efefef url(../images/leftNavBg.png) repeat-x;border-bottom:1px solid #d5d5d5;font-size:11px;color:#878787}.tableStatic.with-tbb{border-top:1px solid #d5d5d5;border-bottom:1px solid #d5d5d5}.tableStatic tfoot tr td,.tableStatic tfoot tr th{padding:8px 10px}.tableStatic tfoot tr td:first-child,.tableStatic tfoot tr th:first-child{border-top:1px solid #e7e7e7}.mainForm fieldset legend{margin:10px 0 0;padding:10px 12px;font-size:1.2em}.moreFields ul li.sep.txt{color:inherit}.widget .head h5.no-icon{padding-left:9px}.conversation ul.tabs li span{display:block;margin:10px 0 0 0;padding-right:5px;float:left;width:16px;height:16px;background-position:0 0}.conversation .gravatar{padding-top:1px;margin-right:10px;float:left}.conversation form textarea{margin-bottom:22px}.conversation .message .body{overflow:auto}.conversation .message blockquote{overflow:auto;width:97%}.conversation .canned_response{float:right;margin:0 2px 22px 0}.dim{height:100%;width:100%;position:fixed;left:0;top:0;z-index:1!important;background-color:#fff;display:none;-khtml-opacity:.5;-moz-opacity:.5;opacity:.5}table.pp td{border-top:1px solid #e7e7e7;padding:10px 14px 10px 14px;margin:12px 12px 12px 0;position:relative;height:10px}table.pp label{padding:0;width:130px}div.vars div.var_category{float:left;width:50%}div.vars div.var_category h1{padding:0 0 0 10px}div.vars div.var_category ul{list-style-position:inside;margin:10px;padding:10px;border:solid 1px #ccc;background-color:#fff}div.bull{width:11px;height:10px;display:block;float:left;margin-top:4px}div.bull.charge.yes,div.bull.task.executed{background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAKCAQAAADI+WwIAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dEAP+Hj8y/AAAACXBIWXMAAAsTAAALEwEAmpwYAAAACXZwQWcAAAALAAAACgCF+qVAAAAAhUlEQVQI103NMQqCABgF4C+Fxg7QHDQ0JkFnaKqlKJBu4Np9hEDoBq2doCYP0B4UBKLYUKZvex+P/+9N/dJ3FXl9S9CopbF9U1pOkAgb3irVanOMlGqldeBoo9CmspMFOFmp/hzLmtuXzvrWvpwJFVJvLLqci8Qmzl8OhzBwcMdD6ilXfwAd9B9f78yTCQAAAABJRU5ErkJggg==)}div.bull.task.pending_setup{background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAKCAQAAADI+WwIAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAACxIAAAsSAdLdfvwAAAAJdnBBZwAAAAsAAAAKAIX6pUAAAACTSURBVAjXTY0xCsJAEEVfdiEgpPAWFpYTvMRWSioDwdIuh7GydbEIeAM7sU1lo42tR1CEdSzMJk4178H/H7qTVK4+A0URTNTMmZhVhEHXMK69/UEiS3Z0sOGOQqBMQAr2pABbgKDlujHQHlgQYpdWeRO7z/0Cj8swOcPyxvOEl/vXN/K2+kw5Zq4PipNR/E+Ft8IX7yMjsFUGo0cAAAAcdEVYdFNvZnR3YXJlAEFkb2JlIEZpcmV3b3JrcyBDUzVxteM2AAAAAElFTkSuQmCC)}div.bull.charge.no,div.bull.task.pending_payment{background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAKCAQAAADI+WwIAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dEAP+Hj8y/AAAACXBIWXMAAAsTAAALEwEAmpwYAAAACXZwQWcAAAALAAAACgCF+qVAAAAAo0lEQVQI1z2NMQrCQBRE32YxGFDwBGJnYZkll0ilpDISLO28k4lFwN7CTsTKSisbK8ELCJFI/BZJdn41j/kzSqiVuZ3r1yzeAAanoajpcOwsW2dxf+0yWGe6CaVzNmgY4VHyQKAiVsIlUlvc9otK4lXugNnJjKqlkpi86X6exIZfNztZBGhKUgr4hBZ3A3UX4ye/CYdeWHch7MOzJ9R3jFLt8we7izGyoi32iQAAAABJRU5ErkJggg==)}#theme-settings h3.section-header{padding:2px 5px 2px 10px;font-size:14px;background:#eee;border-bottom:1px solid #ccc;color:#333;margin-bottom:1px;background-image:url(../images/arrows.png);background-position:98% 10px;background-repeat:no-repeat}#theme-settings h3.section-header.collapsed{background-position:98% -96px}#theme-settings h3.section-header:hover{background-color:#e6f0f5;border-bottom-color:#cfdce4;background-position:98% -18px;cursor:pointer}#theme-settings h3.section-header.collapsed:hover{background-position:98% -124px}#theme-settings fieldset{padding:15px;display:none;background-color:#fdfdfd}#theme-settings fieldset legend{display:none}#theme-settings fieldset h3{font-size:13px;font-weight:700;color:#444;padding:5px 0 5px 0}#theme-settings table{border-spacing:2px;margin-left:10px}#theme-settings table td{vertical-align:middle;padding-bottom:5px}#theme-settings fieldset>table>tbody>tr>td:first-child{width:250px;vertical-align:top}#theme-settings p{margin:0 10px}#theme-settings hr{background:#d5d5d5;width:100%;height:1px;font-size:1px;border:0}#theme-settings .actions{padding:10px;border-top:1px solid #d5d5d5}#theme-settings input[type=email],#theme-settings input[type=password],#theme-settings input[type=text],#theme-settings textarea{padding:2px;border:1px solid #ccc;font-family:monospace;font-size:9pt}#theme-settings input.long,#theme-settings textarea.long{width:350px}#theme-settings input.color{width:50px;margin-right:5px}.sp-boxbilling{padding:1px!important;border:0!important;background:#ccc!important}.sp-boxbilling .sp-preview{margin:0!important;border:0 solid #fff!important;margin:0!important;width:17px!important;height:17px!important}.sp-boxbilling .sp-preview-inner{width:15px!important;height:15px!important;margin:0!important;border:1px solid #fff!important}.sp-boxbilling .sp-dd{display:none}.hover-row:hover{background-color:#e4e4e4!important;transition:background-color .2s ease-in-out;-moz-transition:background-color .2s ease-in-out;-webkit-transition:background-color .2s ease-in-out}.flag{display:inline-block;width:16px;height:11px;background:url(../images/csg-4ffefaac101ed.png) no-repeat top left}.flag-{background-position:-1000px -1000px;width:16px;height:11px}.flag-AD{background-position:0 0;width:16px;height:11px}.flag-AE{background-position:-26px 0;width:16px;height:11px}.flag-AF{background-position:-52px 0;width:16px;height:11px}.flag-AG{background-position:-78px 0;width:16px;height:11px}.flag-AI{background-position:-104px 0;width:16px;height:11px}.flag-AL{background-position:-130px 0;width:16px;height:11px}.flag-AM{background-position:-156px 0;width:16px;height:11px}.flag-AN{background-position:-182px 0;width:16px;height:11px}.flag-AO{background-position:-208px 0;width:16px;height:11px}.flag-AR{background-position:-234px 0;width:16px;height:11px}.flag-AS{background-position:-260px 0;width:16px;height:11px}.flag-AT{background-position:-286px 0;width:16px;height:11px}.flag-AU{background-position:-312px 0;width:16px;height:11px}.flag-AW{background-position:-338px 0;width:16px;height:11px}.flag-AX{background-position:-364px 0;width:16px;height:11px}.flag-AZ{background-position:-390px 0;width:16px;height:11px}.flag-BA{background-position:-416px 0;width:16px;height:11px}.flag-BB{background-position:-442px 0;width:16px;height:11px}.flag-BD{background-position:-468px 0;width:16px;height:11px}.flag-BE{background-position:-494px 0;width:16px;height:11px}.flag-BF{background-position:-520px 0;width:16px;height:11px}.flag-BG{background-position:-546px 0;width:16px;height:11px}.flag-BH{background-position:-572px 0;width:16px;height:11px}.flag-BI{background-position:-598px 0;width:16px;height:11px}.flag-BJ{background-position:-624px 0;width:16px;height:11px}.flag-BM{background-position:-650px 0;width:16px;height:11px}.flag-BN{background-position:-676px 0;width:16px;height:11px}.flag-BO{background-position:-702px 0;width:16px;height:11px}.flag-BR{background-position:-728px 0;width:16px;height:11px}.flag-BS{background-position:-754px 0;width:16px;height:11px}.flag-BT{background-position:-780px 0;width:16px;height:11px}.flag-BV{background-position:-806px 0;width:16px;height:11px}.flag-BW{background-position:-832px 0;width:16px;height:11px}.flag-BY{background-position:-858px 0;width:16px;height:11px}.flag-BZ{background-position:-884px 0;width:16px;height:11px}.flag-CA{background-position:-910px 0;width:16px;height:11px}.flag-CATALONIA{background-position:-936px 0;width:16px;height:11px}.flag-CC{background-position:-962px 0;width:16px;height:11px}.flag-CD{background-position:-988px 0;width:16px;height:11px}.flag-CF{background-position:-1014px 0;width:16px;height:11px}.flag-CG{background-position:-1040px 0;width:16px;height:11px}.flag-CH{background-position:-1066px 0;width:11px;height:11px}.flag-CI{background-position:-1087px 0;width:16px;height:11px}.flag-CK{background-position:-1113px 0;width:16px;height:11px}.flag-CL{background-position:-1139px 0;width:16px;height:11px}.flag-CM{background-position:-1165px 0;width:16px;height:11px}.flag-CN{background-position:-1191px 0;width:16px;height:11px}.flag-CO{background-position:-1217px 0;width:16px;height:11px}.flag-CR{background-position:-1243px 0;width:16px;height:11px}.flag-CS{background-position:-1269px 0;width:16px;height:11px}.flag-CU{background-position:-1295px 0;width:16px;height:11px}.flag-CV{background-position:-1321px 0;width:16px;height:11px}.flag-CX{background-position:-1347px 0;width:16px;height:11px}.flag-CY{background-position:-1373px 0;width:16px;height:11px}.flag-CZ{background-position:-1399px 0;width:16px;height:11px}.flag-DE{background-position:-1425px 0;width:16px;height:11px}.flag-DJ{background-position:-1451px 0;width:16px;height:11px}.flag-DK{background-position:-1477px 0;width:16px;height:11px}.flag-DM{background-position:-1503px 0;width:16px;height:11px}.flag-DO{background-position:-1529px 0;width:16px;height:11px}.flag-DZ{background-position:-1555px 0;width:16px;height:11px}.flag-EC{background-position:-1581px 0;width:16px;height:11px}.flag-EE{background-position:-1607px 0;width:16px;height:11px}.flag-EG{background-position:-1633px 0;width:16px;height:11px}.flag-EH{background-position:-1659px 0;width:16px;height:11px}.flag-ENGLAND{background-position:-1685px 0;width:16px;height:11px}.flag-ER{background-position:-1711px 0;width:16px;height:11px}.flag-ES{background-position:-1737px 0;width:16px;height:11px}.flag-ET{background-position:-1763px 0;width:16px;height:11px}.flag-EUROPEANUNION{background-position:-1789px 0;width:16px;height:11px}.flag-FI{background-position:-1815px 0;width:16px;height:11px}.flag-FJ{background-position:-1841px 0;width:16px;height:11px}.flag-FK{background-position:-1867px 0;width:16px;height:11px}.flag-FM{background-position:-1893px 0;width:16px;height:11px}.flag-FO{background-position:-1919px 0;width:16px;height:11px}.flag-FR{background-position:-1945px 0;width:16px;height:11px}.flag-GA{background-position:-1971px 0;width:16px;height:11px}.flag-GB{background-position:0 -21px;width:16px;height:11px}.flag-GD{background-position:-26px -21px;width:16px;height:11px}.flag-GE{background-position:-52px -21px;width:16px;height:11px}.flag-GF{background-position:-78px -21px;width:16px;height:11px}.flag-GH{background-position:-104px -21px;width:16px;height:11px}.flag-GI{background-position:-130px -21px;width:16px;height:11px}.flag-GL{background-position:-156px -21px;width:16px;height:11px}.flag-GM{background-position:-182px -21px;width:16px;height:11px}.flag-GN{background-position:-208px -21px;width:16px;height:11px}.flag-GP{background-position:-234px -21px;width:16px;height:11px}.flag-GQ{background-position:-260px -21px;width:16px;height:11px}.flag-GR{background-position:-286px -21px;width:16px;height:11px}.flag-GS{background-position:-312px -21px;width:16px;height:11px}.flag-GT{background-position:-338px -21px;width:16px;height:11px}.flag-GU{background-position:-364px -21px;width:16px;height:11px}.flag-GW{background-position:-390px -21px;width:16px;height:11px}.flag-GY{background-position:-416px -21px;width:16px;height:11px}.flag-HK{background-position:-442px -21px;width:16px;height:11px}.flag-HM{background-position:-468px -21px;width:16px;height:11px}.flag-HN{background-position:-494px -21px;width:16px;height:11px}.flag-HR{background-position:-520px -21px;width:16px;height:11px}.flag-HT{background-position:-546px -21px;width:16px;height:11px}.flag-HU{background-position:-572px -21px;width:16px;height:11px}.flag-ID{background-position:-598px -21px;width:16px;height:11px}.flag-IE{background-position:-624px -21px;width:16px;height:11px}.flag-IL{background-position:-650px -21px;width:16px;height:11px}.flag-IN{background-position:-676px -21px;width:16px;height:11px}.flag-IO{background-position:-702px -21px;width:16px;height:11px}.flag-IQ{background-position:-728px -21px;width:16px;height:11px}.flag-IR{background-position:-754px -21px;width:16px;height:11px}.flag-IS{background-position:-780px -21px;width:16px;height:11px}.flag-IT{background-position:-806px -21px;width:16px;height:11px}.flag-JM{background-position:-832px -21px;width:16px;height:11px}.flag-JO{background-position:-858px -21px;width:16px;height:11px}.flag-JP{background-position:-884px -21px;width:16px;height:11px}.flag-KE{background-position:-910px -21px;width:16px;height:11px}.flag-KG{background-position:-936px -21px;width:16px;height:11px}.flag-KH{background-position:-962px -21px;width:16px;height:11px}.flag-KI{background-position:-988px -21px;width:16px;height:11px}.flag-KM{background-position:-1014px -21px;width:16px;height:11px}.flag-KN{background-position:-1040px -21px;width:16px;height:11px}.flag-KP{background-position:-1066px -21px;width:16px;height:11px}.flag-KR{background-position:-1092px -21px;width:16px;height:11px}.flag-KW{background-position:-1118px -21px;width:16px;height:11px}.flag-KY{background-position:-1144px -21px;width:16px;height:11px}.flag-KZ{background-position:-1170px -21px;width:16px;height:11px}.flag-LA{background-position:-1196px -21px;width:16px;height:11px}.flag-LB{background-position:-1222px -21px;width:16px;height:11px}.flag-LC{background-position:-1248px -21px;width:16px;height:11px}.flag-LI{background-position:-1274px -21px;width:16px;height:11px}.flag-LK{background-position:-1300px -21px;width:16px;height:11px}.flag-LR{background-position:-1326px -21px;width:16px;height:11px}.flag-LS{background-position:-1352px -21px;width:16px;height:11px}.flag-LT{background-position:-1378px -21px;width:16px;height:11px}.flag-LU{background-position:-1404px -21px;width:16px;height:11px}.flag-LV{background-position:-1430px -21px;width:16px;height:11px}.flag-LY{background-position:-1456px -21px;width:16px;height:11px}.flag-MA{background-position:-1482px -21px;width:16px;height:11px}.flag-MC{background-position:-1508px -21px;width:16px;height:11px}.flag-MD{background-position:-1534px -21px;width:16px;height:11px}.flag-ME{background-position:-1560px -21px;width:16px;height:12px}.flag-MG{background-position:-1586px -21px;width:16px;height:11px}.flag-MH{background-position:-1612px -21px;width:16px;height:11px}.flag-MK{background-position:-1638px -21px;width:16px;height:11px}.flag-ML{background-position:-1664px -21px;width:16px;height:11px}.flag-MM{background-position:-1690px -21px;width:16px;height:11px}.flag-MN{background-position:-1716px -21px;width:16px;height:11px}.flag-MO{background-position:-1742px -21px;width:16px;height:11px}.flag-MP{background-position:-1768px -21px;width:16px;height:11px}.flag-MQ{background-position:-1794px -21px;width:16px;height:11px}.flag-MR{background-position:-1820px -21px;width:16px;height:11px}.flag-MS{background-position:-1846px -21px;width:16px;height:11px}.flag-MT{background-position:-1872px -21px;width:16px;height:11px}.flag-MU{background-position:-1898px -21px;width:16px;height:11px}.flag-MV{background-position:-1924px -21px;width:16px;height:11px}.flag-MW{background-position:-1950px -21px;width:16px;height:11px}.flag-MX{background-position:-1976px -21px;width:16px;height:11px}.flag-MY{background-position:0 -43px;width:16px;height:11px}.flag-MZ{background-position:-26px -43px;width:16px;height:11px}.flag-NA{background-position:-52px -43px;width:16px;height:11px}.flag-NC{background-position:-78px -43px;width:16px;height:11px}.flag-NE{background-position:-104px -43px;width:16px;height:11px}.flag-NF{background-position:-130px -43px;width:16px;height:11px}.flag-NG{background-position:-156px -43px;width:16px;height:11px}.flag-NI{background-position:-182px -43px;width:16px;height:11px}.flag-NL{background-position:-208px -43px;width:16px;height:11px}.flag-NO{background-position:-234px -43px;width:16px;height:11px}.flag-NP{background-position:-260px -43px;width:9px;height:11px}.flag-NR{background-position:-279px -43px;width:16px;height:11px}.flag-NU{background-position:-305px -43px;width:16px;height:11px}.flag-NZ{background-position:-331px -43px;width:16px;height:11px}.flag-OM{background-position:-357px -43px;width:16px;height:11px}.flag-PA{background-position:-383px -43px;width:16px;height:11px}.flag-PE{background-position:-409px -43px;width:16px;height:11px}.flag-PF{background-position:-435px -43px;width:16px;height:11px}.flag-PG{background-position:-461px -43px;width:16px;height:11px}.flag-PH{background-position:-487px -43px;width:16px;height:11px}.flag-PK{background-position:-513px -43px;width:16px;height:11px}.flag-PL{background-position:-539px -43px;width:16px;height:11px}.flag-PM{background-position:-565px -43px;width:16px;height:11px}.flag-PN{background-position:-591px -43px;width:16px;height:11px}.flag-PR{background-position:-617px -43px;width:16px;height:11px}.flag-PS{background-position:-643px -43px;width:16px;height:11px}.flag-PT{background-position:-669px -43px;width:16px;height:11px}.flag-PW{background-position:-695px -43px;width:16px;height:11px}.flag-PY{background-position:-721px -43px;width:16px;height:11px}.flag-QA{background-position:-747px -43px;width:16px;height:11px}.flag-RE{background-position:-773px -43px;width:16px;height:11px}.flag-RO{background-position:-799px -43px;width:16px;height:11px}.flag-RS{background-position:-825px -43px;width:16px;height:11px}.flag-RU{background-position:-851px -43px;width:16px;height:11px}.flag-RW{background-position:-877px -43px;width:16px;height:11px}.flag-SA{background-position:-903px -43px;width:16px;height:11px}.flag-SB{background-position:-929px -43px;width:16px;height:11px}.flag-SC{background-position:-955px -43px;width:16px;height:11px}.flag-SCOTLAND{background-position:-981px -43px;width:16px;height:11px}.flag-SD{background-position:-1007px -43px;width:16px;height:11px}.flag-SE{background-position:-1033px -43px;width:16px;height:11px}.flag-SG{background-position:-1059px -43px;width:16px;height:11px}.flag-SH{background-position:-1085px -43px;width:16px;height:11px}.flag-SI{background-position:-1111px -43px;width:16px;height:11px}.flag-SJ{background-position:-1137px -43px;width:16px;height:11px}.flag-SK{background-position:-1163px -43px;width:16px;height:11px}.flag-SL{background-position:-1189px -43px;width:16px;height:11px}.flag-SM{background-position:-1215px -43px;width:16px;height:11px}.flag-SN{background-position:-1241px -43px;width:16px;height:11px}.flag-SO{background-position:-1267px -43px;width:16px;height:11px}.flag-SR{background-position:-1293px -43px;width:16px;height:11px}.flag-ST{background-position:-1319px -43px;width:16px;height:11px}.flag-SV{background-position:-1345px -43px;width:16px;height:11px}.flag-SY{background-position:-1371px -43px;width:16px;height:11px}.flag-SZ{background-position:-1397px -43px;width:16px;height:11px}.flag-TC{background-position:-1423px -43px;width:16px;height:11px}.flag-TD{background-position:-1449px -43px;width:16px;height:11px}.flag-TF{background-position:-1475px -43px;width:16px;height:11px}.flag-TG{background-position:-1501px -43px;width:16px;height:11px}.flag-TH{background-position:-1527px -43px;width:16px;height:11px}.flag-TJ{background-position:-1553px -43px;width:16px;height:11px}.flag-TK{background-position:-1579px -43px;width:16px;height:11px}.flag-TL{background-position:-1605px -43px;width:16px;height:11px}.flag-TM{background-position:-1631px -43px;width:16px;height:11px}.flag-TN{background-position:-1657px -43px;width:16px;height:11px}.flag-TO{background-position:-1683px -43px;width:16px;height:11px}.flag-TR{background-position:-1709px -43px;width:16px;height:11px}.flag-TT{background-position:-1735px -43px;width:16px;height:11px}.flag-TV{background-position:-1761px -43px;width:16px;height:11px}.flag-TW{background-position:-1787px -43px;width:16px;height:11px}.flag-TZ{background-position:-1813px -43px;width:16px;height:11px}.flag-UA{background-position:-1839px -43px;width:16px;height:11px}.flag-UK{background-position:0 -21px;width:16px;height:11px}.flag-UG{background-position:-1865px -43px;width:16px;height:11px}.flag-UM{background-position:-1891px -43px;width:16px;height:11px}.flag-US{background-position:-1917px -43px;width:16px;height:11px}.flag-UY{background-position:-1943px -43px;width:16px;height:11px}.flag-UZ{background-position:-1969px -43px;width:16px;height:11px}.flag-VA{background-position:0 -65px;width:16px;height:11px}.flag-VC{background-position:-26px -65px;width:16px;height:11px}.flag-VE{background-position:-52px -65px;width:16px;height:11px}.flag-VG{background-position:-78px -65px;width:16px;height:11px}.flag-VI{background-position:-104px -65px;width:16px;height:11px}.flag-VN{background-position:-130px -65px;width:16px;height:11px}.flag-VU{background-position:-156px -65px;width:16px;height:11px}.flag-WALES{background-position:-182px -65px;width:16px;height:11px}.flag-WF{background-position:-208px -65px;width:16px;height:11px}.flag-WS{background-position:-234px -65px;width:16px;height:11px}.flag-YE{background-position:-260px -65px;width:16px;height:11px}.flag-YT{background-position:-286px -65px;width:16px;height:11px}.flag-ZA{background-position:-312px -65px;width:16px;height:11px}.flag-ZM{background-position:-338px -65px;width:16px;height:11px}.flag-ZW{background-position:-364px -65px;width:16px;height:11px}a,abbr,acronym,address,applet,b,big,blockquote,body,caption,center,cite,code,dd,del,dfn,div,dl,dt,em,fieldset,font,form,h1,h2,h3,h4,h5,h6,html,i,iframe,img,ins,kbd,label,legend,li,object,ol,p,pre,q,s,samp,small,span,strike,strong,sub,sup,table,tbody,td,tfoot,th,thead,tr,tt,u,ul,var{margin:0;padding:0;border:0;outline:0;font-size:100%;vertical-align:baseline;background:0 0}ol,ul{list-style:none}blockquote,q{quotes:none}blockquote:after,blockquote:before,q:after,q:before{content:'';content:none}:focus{outline:0}ins{text-decoration:none}del{text-decoration:line-through}table{border-collapse:collapse}*,* focus{outline:0;margin:0;padding:0}textarea{overflow:auto}input[type=password],input[type=text],textarea{font-family:Arial,Helvetica,sans-serif;font-size:11px}button,input[type=submit]{font-family:Arial,Helvetica,sans-serif}img{border:0}ul{list-style:none;margin:0;padding:0}p{margin:0;padding:0}:focus{outline:0}a{text-decoration:none;color:#2b6893}.normal{font-style:normal}.normalFont{font-style:normal;font-weight:400}.mt40{margin-top:40px}.nomargin{margin:0!important}.m10{margin:10px 0}.m15{margin:15px 0}.m20{margin:20px 0}.mr5{margin-right:5px}.mr10{margin-right:10px}.mr15{margin-right:15px}.mr20{margin-right:20px}.mr25{margin-right:25px}.mr30{margin-right:30px}.mb0{margin-bottom:0}.mb5{margin-bottom:5px}.mb10{margin-bottom:10px}.mb15{margin-bottom:15px}.mb20{margin-bottom:20px}.mb25{margin-bottom:25px}.mb30{margin-bottom:30px}.mb40{margin-bottom:40px}.mt0{margin-top:0}.mt5{margin-top:5px}.mt10{margin-top:10px}.mt12{margin-top:12px}.mt15{margin-top:15px}.mt20{margin-top:20px}.mt25{margin-top:25px}.mt30{margin-top:30px}.ml5{margin-left:5px}.ml10{margin-left:10px}.ml15{margin-left:15px}.ml20{margin-left:20px}.ml25{margin-left:25px}.ml30{margin-left:30px}.mr5{margin-right:5px}.mr10{margin-right:10px}.mr15{margin-right:15px}.mr20{margin-right:20px}.mr25{margin-right:25px}.mr30{margin-right:30px}.pb0{padding-bottom:0!important}.pb5{padding-bottom:5px}.pb10{padding-bottom:10px}.pb15{padding-bottom:15px}.pb20{padding-bottom:20px}.pb25{padding-bottom:25px}.pb30{padding-bottom:30px}.pt0{padding-top:0}.pt5{padding-top:5px}.pt10{padding-top:10px}.pt15{padding-top:15px}.pt20{padding-top:20px}.pt25{padding-top:25px}.pt30{padding-top:30px}input::-moz-focus-inner{border:0;padding:0}a.button::-moz-focus-inner{border:0;padding-top:20px}.paging_two_button .ui-button{float:left;cursor:pointer}.paging_full_numbers .ui-button{padding:2px 6px;margin:0;cursor:pointer}.dataTables_paginate .ui-button{margin-right:-.1em!important}.dataTables_wrapper .ui-toolbar{padding:5px}.dataTables_paginate{width:auto}.dataTables_info{padding:7px 0 0 80px;color:#878787}table.display thead th{padding:4px 0 3px 10px;cursor:pointer;font-size:11px}div.dataTables_wrapper .ui-widget-header{font-weight:400;background:#efefef url(../images/leftNavBg.png) repeat-x;border-top:1px solid #d5d5d5;margin-top:-1px;border-right:none}table.display thead th div.DataTables_sort_wrapper{position:relative;padding-right:20px;color:#878787}table.display thead th div.DataTables_sort_wrapper span{position:absolute;top:50%;margin-top:-8px;right:5px}.dataTables_wrapper{position:relative;min-height:302px;clear:both}.dataTables_processing{position:absolute;top:0;left:50%;width:250px;margin-left:-125px;border:1px solid #ddd;text-align:center;color:#999;font-size:11px;padding:2px 0}.dataTables_length{float:left;color:#878787;margin:7px 5px 0 5px}.dataTables_length label{padding-top:10px;font-size:11px}.dataTables_length select{font-size:11px;margin:0 5px}.dataTables_filter{text-align:left;margin:4px 8px 2px 10px;position:absolute;right:0;top:-34px;color:#878787;font-size:11px}.dataTables_filter input[type=text]{padding:3px 5px;border:1px solid #d5d5d5;width:200px;position:relative;margin-left:6px;-moz-border-radius:2px;-webkit-border-radius:2px;-khtml-border-radius:2px;border-radius:2px;color:#878787}.dataTables_filter .srch{position:absolute;right:6px;top:7px;background:url(../images/searchSmall.png) no-repeat 0 0;border:none;width:9px;height:9px}.dataTables_info{float:left}.dataTables_paginate{text-align:right;margin:6px}.paginate_disabled_next,.paginate_disabled_previous,.paginate_enabled_next,.paginate_enabled_previous{height:19px;width:19px;margin-left:3px;float:left}.paginate_disabled_previous{background-image:url(../images/back_disabled.jpg)}.paginate_enabled_previous{background-image:url(../images/back_enabled.jpg)}.paginate_disabled_next{background-image:url(../images/forward_disabled.jpg)}.paginate_enabled_next{background-image:url(../images/forward_enabled.jpg)}table.display{margin:0 auto;width:100%;clear:both;border-collapse:collapse}table.display tfoot th{padding:3px 0 3px 10px;font-weight:700;font-weight:400}table.display tr.heading2 td{border-bottom:1px solid #aaa}table.display td{padding:8px 10px}table.display td.center{text-align:center}.sorting_asc{background:url(../images/sort_asc.png) no-repeat center right}.sorting_desc{background:url(../images/sort_desc.png) no-repeat center right}.sorting{background:url(../images/sort_both.png) no-repeat center right}.sorting_asc_disabled{background:url(../images/sort_asc_disabled.png) no-repeat center right}.sorting_desc_disabled{background:url(../images/sort_desc_disabled.png) no-repeat center right}table.display tr.odd.gradeA{background-color:#dfd}table.display tr.even.gradeA{background-color:#efe}table.display tr{border-bottom:1px solid #e7e7e7}table.display td{border-left:1px solid #e7e7e7}table.display td:first-child{border-left:none}table.display tr.odd.gradeA{background-color:#fafafa}table.display tr.even.gradeA{background-color:#f5f5f5}table.display tr.odd.gradeC{background-color:#ddf}table.display tr.even.gradeC{background-color:#eef}table.display tr.odd.gradeX{background-color:#fdd}table.display tr.even.gradeX{background-color:#fee}table.display tr.odd.gradeU{background-color:#ddd}table.display tr.even.gradeU{background-color:#eee}tr.odd{background-color:#e2e4ff}tr.even{background-color:#fff}.dataTables_scroll{clear:both}.bottom,.top{padding:15px;background-color:#f5f5f5;border:1px solid #ccc}.top .dataTables_info{float:none}.clear{clear:both}.dataTables_empty{text-align:center}tfoot input{margin:.5em 0;width:100%;color:#444}tfoot input.search_init{color:#999}td.group{background-color:#d1cfd0;border-bottom:2px solid #a19b9e;border-top:2px solid #a19b9e}td.details{background-color:#d1cfd0;border:2px solid #a19b9e}.example_alt_pagination div.dataTables_info{width:40%}.paging_full_numbers span.paginate_active,.paging_full_numbers span.paginate_button{border:1px solid #aaa;-webkit-border-radius:5px;-moz-border-radius:5px;padding:2px 5px;margin:0 3px;cursor:pointer}.paging_full_numbers span.paginate_button{background-color:#ddd}.paging_full_numbers span.paginate_button:hover{background-color:#ccc}.paging_full_numbers span.paginate_active{background-color:#99b3ff}table.display tr.even.row_selected td{background-color:#b0bed9}table.display tr.odd.row_selected td{background-color:#9fafd1}tr.odd td.sorting_1{background-color:#d3d6ff}tr.odd td.sorting_2{background-color:#dadcff}tr.odd td.sorting_3{background-color:#e0e2ff}tr.even td.sorting_1{background-color:#eaebff}tr.even td.sorting_2{background-color:#f2f3ff}tr.even td.sorting_3{background-color:#f9f9ff}tr.odd.gradeA td.sorting_1{background-color:#f4f4f4}tr.odd.gradeA td.sorting_2{background-color:#d1ffd1}tr.odd.gradeA td.sorting_3{background-color:#d1ffd1}tr.even.gradeA td.sorting_1{background-color:#efefef}tr.even.gradeA td.sorting_2{background-color:#e2ffe2}tr.even.gradeA td.sorting_3{background-color:#e2ffe2}tr.odd.gradeC td.sorting_1{background-color:#c4c4ff}tr.odd.gradeC td.sorting_2{background-color:#d1d1ff}tr.odd.gradeC td.sorting_3{background-color:#d1d1ff}tr.even.gradeC td.sorting_1{background-color:#d5d5ff}tr.even.gradeC td.sorting_2{background-color:#e2e2ff}tr.even.gradeC td.sorting_3{background-color:#e2e2ff}tr.odd.gradeX td.sorting_1{background-color:#ffc4c4}tr.odd.gradeX td.sorting_2{background-color:#ffd1d1}tr.odd.gradeX td.sorting_3{background-color:#ffd1d1}tr.even.gradeX td.sorting_1{background-color:#ffd5d5}tr.even.gradeX td.sorting_2{background-color:#ffe2e2}tr.even.gradeX td.sorting_3{background-color:#ffe2e2}tr.odd.gradeU td.sorting_1{background-color:#c4c4c4}tr.odd.gradeU td.sorting_2{background-color:#d1d1d1}tr.odd.gradeU td.sorting_3{background-color:#d1d1d1}tr.even.gradeU td.sorting_1{background-color:#d5d5d5}tr.even.gradeU td.sorting_2{background-color:#e2e2e2}tr.even.gradeU td.sorting_3{background-color:#e2e2e2}#example tbody tr.even td.highlighted,.ex_highlight #example tbody tr.even:hover{background-color:#ecffb3}#example tbody tr.odd td.highlighted,.ex_highlight #example tbody tr.odd:hover{background-color:#e6ff99}.ui-helper-hidden{display:none}.ui-helper-hidden-accessible{position:absolute;left:-99999999px}.ui-helper-reset{margin:0;padding:0;border:0;outline:0;line-height:1.3;text-decoration:none;font-size:100%;list-style:none}.ui-helper-clearfix:after{content:".";display:block;height:0;clear:both;visibility:hidden}.ui-helper-clearfix{display:inline-block}* html .ui-helper-clearfix{height:1%}.ui-helper-clearfix{display:block}.ui-helper-zfix{width:100%;height:100%;top:0;left:0;position:absolute;opacity:0;filter:Alpha(Opacity=0)}.ui-state-disabled{cursor:default!important}.ui-icon{display:block;text-indent:-99999px;overflow:hidden;background-repeat:no-repeat}.ui-widget-overlay{position:absolute;top:0;left:0;width:100%;height:100%}.ui-widget{font-size:12px}.ui-widget .ui-widget{font-size:1em}.ui-widget button,.ui-widget input,.ui-widget select,.ui-widget textarea{font-family:Verdana,Arial,sans-serif;font-size:1em}.ui-widget-content a{color:#222}.ui-widget-header{font-weight:700}.ui-widget-header a{color:#222}.ui-state-default,.ui-widget-content .ui-state-default,.ui-widget-header .ui-state-default{border-left:1px solid #d5d5d5;font-weight:400;border-bottom:1px solid #d5d5d5}th.ui-state-default:first-child{border-left:none}.ui-state-default a,.ui-state-default a:link,.ui-state-default a:visited{color:#555;text-decoration:none}.ui-state-focus,.ui-state-hover,.ui-widget-content .ui-state-focus,.ui-widget-content .ui-state-hover,.ui-widget-header .ui-state-focus,.ui-widget-header .ui-state-hover{background:#fafafa;font-weight:400;color:#212121}.ui-state-hover a,.ui-state-hover a:hover{color:#797979;text-decoration:none}.ui-state-active,.ui-widget-content .ui-state-active,.ui-widget-header .ui-state-active{background:#fafafa;font-weight:400;color:#797979}.ui-state-active a,.ui-state-active a:link,.ui-state-active a:visited{color:#797979;text-decoration:none}.ui-widget :active{outline:0}.ui-state-highlight a,.ui-widget-content .ui-state-highlight a,.ui-widget-header .ui-state-highlight a{color:#363636}.ui-state-error,.ui-widget-content .ui-state-error,.ui-widget-header .ui-state-error{border:1px solid #cd0a0a;background:#fef1ec url(../images/jquery_ui/ui-bg_glass_95_fef1ec_1x400.png) 50% 50% repeat-x;color:#cd0a0a}.ui-state-error a,.ui-widget-content .ui-state-error a,.ui-widget-header .ui-state-error a{color:#cd0a0a}.ui-state-error-text,.ui-widget-content .ui-state-error-text,.ui-widget-header .ui-state-error-text{color:#cd0a0a}.ui-priority-primary,.ui-widget-content .ui-priority-primary,.ui-widget-header .ui-priority-primary{font-weight:700}.ui-priority-secondary,.ui-widget-content .ui-priority-secondary,.ui-widget-header .ui-priority-secondary{opacity:.7;filter:Alpha(Opacity=70);font-weight:400}.ui-state-disabled,.ui-widget-content .ui-state-disabled,.ui-widget-header .ui-state-disabled{opacity:.35;filter:Alpha(Opacity=35);background-image:none}.ui-icon{width:16px;height:16px;background-image:url(../images/jquery_ui/ui-icons_222222_256x240.png)}.ui-widget-content .ui-icon{background-image:url(../images/jquery_ui/ui-icons_222222_256x240.png)}.ui-widget-header .ui-icon{background-image:url(../images/jquery_ui/ui-icons_222222_256x240.png)}.ui-state-default .ui-icon{background-image:url(../images/jquery_ui/ui-icons_888888_256x240.png)}.ui-state-focus .ui-icon,.ui-state-hover .ui-icon{background-image:url(../images/jquery_ui/ui-icons_454545_256x240.png)}.ui-state-active .ui-icon{background-image:url(../images/jquery_ui/ui-icons_454545_256x240.png)}.ui-state-highlight .ui-icon{background-image:url(../images/jquery_ui/ui-icons_2e83ff_256x240.png)}.ui-state-error .ui-icon,.ui-state-error-text .ui-icon{background-image:url(../images/jquery_ui/ui-icons_cd0a0a_256x240.png)}.ui-icon-carat-1-n{background-position:0 0}.ui-icon-carat-1-ne{background-position:-16px 0}.ui-icon-carat-1-e{background-position:-32px 0}.ui-icon-carat-1-se{background-position:-48px 0}.ui-icon-carat-1-s{background-position:-64px 0}.ui-icon-carat-1-sw{background-position:-80px 0}.ui-icon-carat-1-w{background-position:-96px 0}.ui-icon-carat-1-nw{background-position:-112px 0}.ui-icon-carat-2-n-s{background-position:-128px 0}.ui-icon-carat-2-e-w{background-position:-144px 0}.ui-icon-triangle-1-n{background-position:0 -16px}.ui-icon-triangle-1-ne{background-position:-16px -16px}.ui-icon-triangle-1-e{background-position:-32px -16px}.ui-icon-triangle-1-se{background-position:-48px -16px}.ui-icon-triangle-1-s{background-position:-64px -16px}.ui-icon-triangle-1-sw{background-position:-80px -16px}.ui-icon-triangle-1-w{background-position:-96px -16px}.ui-icon-triangle-1-nw{background-position:-112px -16px}.ui-icon-triangle-2-n-s{background-position:-128px -16px}.ui-icon-triangle-2-e-w{background-position:-144px -16px}.ui-icon-arrow-1-n{background-position:0 -32px}.ui-icon-arrow-1-ne{background-position:-16px -32px}.ui-icon-arrow-1-e{background-position:-32px -32px}.ui-icon-arrow-1-se{background-position:-48px -32px}.ui-icon-arrow-1-s{background-position:-64px -32px}.ui-icon-arrow-1-sw{background-position:-80px -32px}.ui-icon-arrow-1-w{background-position:-96px -32px}.ui-icon-arrow-1-nw{background-position:-112px -32px}.ui-icon-arrow-2-n-s{background-position:-128px -32px}.ui-icon-arrow-2-ne-sw{background-position:-144px -32px}.ui-icon-arrow-2-e-w{background-position:-160px -32px}.ui-icon-arrow-2-se-nw{background-position:-176px -32px}.ui-icon-arrowstop-1-n{background-position:-192px -32px}.ui-icon-arrowstop-1-e{background-position:-208px -32px}.ui-icon-arrowstop-1-s{background-position:-224px -32px}.ui-icon-arrowstop-1-w{background-position:-240px -32px}.ui-icon-arrowthick-1-n{background-position:0 -48px}.ui-icon-arrowthick-1-ne{background-position:-16px -48px}.ui-icon-arrowthick-1-e{background-position:-32px -48px}.ui-icon-arrowthick-1-se{background-position:-48px -48px}.ui-icon-arrowthick-1-s{background-position:-64px -48px}.ui-icon-arrowthick-1-sw{background-position:-80px -48px}.ui-icon-arrowthick-1-w{background-position:-96px -48px}.ui-icon-arrowthick-1-nw{background-position:-112px -48px}.ui-icon-arrowthick-2-n-s{background-position:-128px -48px}.ui-icon-arrowthick-2-ne-sw{background-position:-144px -48px}.ui-icon-arrowthick-2-e-w{background-position:-160px -48px}.ui-icon-arrowthick-2-se-nw{background-position:-176px -48px}.ui-icon-arrowthickstop-1-n{background-position:-192px -48px}.ui-icon-arrowthickstop-1-e{background-position:-208px -48px}.ui-icon-arrowthickstop-1-s{background-position:-224px -48px}.ui-icon-arrowthickstop-1-w{background-position:-240px -48px}.ui-icon-arrowreturnthick-1-w{background-position:0 -64px}.ui-icon-arrowreturnthick-1-n{background-position:-16px -64px}.ui-icon-arrowreturnthick-1-e{background-position:-32px -64px}.ui-icon-arrowreturnthick-1-s{background-position:-48px -64px}.ui-icon-arrowreturn-1-w{background-position:-64px -64px}.ui-icon-arrowreturn-1-n{background-position:-80px -64px}.ui-icon-arrowreturn-1-e{background-position:-96px -64px}.ui-icon-arrowreturn-1-s{background-position:-112px -64px}.ui-icon-arrowrefresh-1-w{background-position:-128px -64px}.ui-icon-arrowrefresh-1-n{background-position:-144px -64px}.ui-icon-arrowrefresh-1-e{background-position:-160px -64px}.ui-icon-arrowrefresh-1-s{background-position:-176px -64px}.ui-icon-arrow-4{background-position:0 -80px}.ui-icon-arrow-4-diag{background-position:-16px -80px}.ui-icon-extlink{background-position:-32px -80px}.ui-icon-newwin{background-position:-48px -80px}.ui-icon-refresh{background-position:-64px -80px}.ui-icon-shuffle{background-position:-80px -80px}.ui-icon-transfer-e-w{background-position:-96px -80px}.ui-icon-transferthick-e-w{background-position:-112px -80px}.ui-icon-folder-collapsed{background-position:0 -96px}.ui-icon-folder-open{background-position:-16px -96px}.ui-icon-document{background-position:-32px -96px}.ui-icon-document-b{background-position:-48px -96px}.ui-icon-note{background-position:-64px -96px}.ui-icon-mail-closed{background-position:-80px -96px}.ui-icon-mail-open{background-position:-96px -96px}.ui-icon-suitcase{background-position:-112px -96px}.ui-icon-comment{background-position:-128px -96px}.ui-icon-person{background-position:-144px -96px}.ui-icon-print{background-position:-160px -96px}.ui-icon-trash{background-position:-176px -96px}.ui-icon-locked{background-position:-192px -96px}.ui-icon-unlocked{background-position:-208px -96px}.ui-icon-bookmark{background-position:-224px -96px}.ui-icon-tag{background-position:-240px -96px}.ui-icon-home{background-position:0 -112px}.ui-icon-flag{background-position:-16px -112px}.ui-icon-calendar{background-position:-32px -112px}.ui-icon-cart{background-position:-48px -112px}.ui-icon-pencil{background-position:-64px -112px}.ui-icon-clock{background-position:-80px -112px}.ui-icon-disk{background-position:-96px -112px}.ui-icon-calculator{background-position:-112px -112px}.ui-icon-zoomin{background-position:-128px -112px}.ui-icon-zoomout{background-position:-144px -112px}.ui-icon-search{background-position:-160px -112px}.ui-icon-wrench{background-position:-176px -112px}.ui-icon-gear{background-position:-192px -112px}.ui-icon-heart{background-position:-208px -112px}.ui-icon-star{background-position:-224px -112px}.ui-icon-link{background-position:-240px -112px}.ui-icon-cancel{background-position:0 -128px}.ui-icon-plus{background-position:-16px -128px}.ui-icon-plusthick{background-position:-32px -128px}.ui-icon-minus{background-position:-48px -128px}.ui-icon-minusthick{background-position:-64px -128px}.ui-icon-close{background-position:-80px -128px}.ui-icon-closethick{background-position:-96px -128px}.ui-icon-key{background-position:-112px -128px}.ui-icon-lightbulb{background-position:-128px -128px}.ui-icon-scissors{background-position:-144px -128px}.ui-icon-clipboard{background-position:-160px -128px}.ui-icon-copy{background-position:-176px -128px}.ui-icon-contact{background-position:-192px -128px}.ui-icon-image{background-position:-208px -128px}.ui-icon-video{background-position:-224px -128px}.ui-icon-script{background-position:-240px -128px}.ui-icon-alert{background-position:0 -144px}.ui-icon-info{background-position:-16px -144px}.ui-icon-notice{background-position:-32px -144px}.ui-icon-help{background-position:-48px -144px}.ui-icon-check{background-position:-64px -144px}.ui-icon-bullet{background-position:-80px -144px}.ui-icon-radio-off{background-position:-96px -144px}.ui-icon-radio-on{background-position:-112px -144px}.ui-icon-pin-w{background-position:-128px -144px}.ui-icon-pin-s{background-position:-144px -144px}.ui-icon-play{background-position:0 -160px}.ui-icon-pause{background-position:-16px -160px}.ui-icon-seek-next{background-position:-32px -160px}.ui-icon-seek-prev{background-position:-48px -160px}.ui-icon-seek-end{background-position:-64px -160px}.ui-icon-seek-start{background-position:-80px -160px}.ui-icon-seek-first{background-position:-80px -160px}.ui-icon-stop{background-position:-96px -160px}.ui-icon-eject{background-position:-112px -160px}.ui-icon-volume-off{background-position:-128px -160px}.ui-icon-volume-on{background-position:-144px -160px}.ui-icon-power{background-position:0 -176px}.ui-icon-signal-diag{background-position:-16px -176px}.ui-icon-signal{background-position:-32px -176px}.ui-icon-battery-0{background-position:-48px -176px}.ui-icon-battery-1{background-position:-64px -176px}.ui-icon-battery-2{background-position:-80px -176px}.ui-icon-battery-3{background-position:-96px -176px}.ui-icon-circle-plus{background-position:0 -192px}.ui-icon-circle-minus{background-position:-16px -192px}.ui-icon-circle-close{background-position:-32px -192px}.ui-icon-circle-triangle-e{background-position:-48px -192px}.ui-icon-circle-triangle-s{background-position:-64px -192px}.ui-icon-circle-triangle-w{background-position:-80px -192px}.ui-icon-circle-triangle-n{background-position:-96px -192px}.ui-icon-circle-arrow-e{background-position:-112px -192px}.ui-icon-circle-arrow-s{background-position:-128px -192px}.ui-icon-circle-arrow-w{background-position:-144px -192px}.ui-icon-circle-arrow-n{background-position:-160px -192px}.ui-icon-circle-zoomin{background-position:-176px -192px}.ui-icon-circle-zoomout{background-position:-192px -192px}.ui-icon-circle-check{background-position:-208px -192px}.ui-icon-circlesmall-plus{background-position:0 -208px}.ui-icon-circlesmall-minus{background-position:-16px -208px}.ui-icon-circlesmall-close{background-position:-32px -208px}.ui-icon-squaresmall-plus{background-position:-48px -208px}.ui-icon-squaresmall-minus{background-position:-64px -208px}.ui-icon-squaresmall-close{background-position:-80px -208px}.ui-icon-grip-dotted-vertical{background-position:0 -224px}.ui-icon-grip-dotted-horizontal{background-position:-16px -224px}.ui-icon-grip-solid-vertical{background-position:-32px -224px}.ui-icon-grip-solid-horizontal{background-position:-48px -224px}.ui-icon-gripsmall-diagonal-se{background-position:-64px -224px}.ui-icon-grip-diagonal-se{background-position:-80px -224px}.ui-corner-tl{-moz-border-radius-topleft:2px;-webkit-border-top-left-radius:2px;border-top-left-radius:2px}.ui-corner-tr{-moz-border-radius-topright:2px;-webkit-border-top-right-radius:2px;border-top-right-radius:2px}.ui-corner-bl{-moz-border-radius-bottomleft:2px;-webkit-border-bottom-left-radius:2px;border-bottom-left-radius:2px}.ui-corner-br{-moz-border-radius-bottomright:2px;-webkit-border-bottom-right-radius:2px;border-bottom-right-radius:2px}.ui-corner-top{-moz-border-radius-topleft:2px;-webkit-border-top-left-radius:2px;border-top-left-radius:2px;-moz-border-radius-topright:2px;-webkit-border-top-right-radius:2px;border-top-right-radius:2px}.ui-corner-bottom{-moz-border-radius-bottomleft:2px;-webkit-border-bottom-left-radius:2px;border-bottom-left-radius:2px;-moz-border-radius-bottomright:2px;-webkit-border-bottom-right-radius:2px;border-bottom-right-radius:2px}.ui-corner-right{-moz-border-radius-topright:2px;-webkit-border-top-right-radius:2px;border-top-right-radius:2px;-moz-border-radius-bottomright:2px;-webkit-border-bottom-right-radius:2px;border-bottom-right-radius:2px}.ui-corner-left{-moz-border-radius-topleft:2px;-webkit-border-top-left-radius:2px;border-top-left-radius:2px;-moz-border-radius-bottomleft:2px;-webkit-border-bottom-left-radius:2px;border-bottom-left-radius:2px}.ui-corner-all{-moz-border-radius:2px;-webkit-border-radius:2px;border-radius:2px}.ui-widget-overlay{background:#aaa url(../images/jquery_ui/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x;opacity:.3;filter:Alpha(Opacity=30)}.ui-widget-shadow{margin:-8px 0 0 -8px;padding:8px;background:#aaa url(../images/jquery_ui/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x;opacity:.3;filter:Alpha(Opacity=30);-moz-border-radius:8px;-webkit-border-radius:8px;border-radius:8px}.ui-resizable{position:relative}.ui-resizable-handle{position:absolute;font-size:.1px;z-index:99999;display:block}.ui-resizable-autohide .ui-resizable-handle,.ui-resizable-disabled .ui-resizable-handle{display:none}.ui-resizable-n{cursor:n-resize;height:7px;width:100%;top:-5px;left:0}.ui-resizable-s{cursor:s-resize;height:7px;width:100%;bottom:-5px;left:0}.ui-resizable-e{cursor:e-resize;width:7px;right:-5px;top:0;height:100%}.ui-resizable-w{cursor:w-resize;width:7px;left:-5px;top:0;height:100%}.ui-resizable-se{cursor:se-resize;width:12px;height:12px;right:1px;bottom:1px}.ui-resizable-sw{cursor:sw-resize;width:9px;height:9px;left:-5px;bottom:-5px}.ui-resizable-nw{cursor:nw-resize;width:9px;height:9px;left:-5px;top:-5px}.ui-resizable-ne{cursor:ne-resize;width:9px;height:9px;right:-5px;top:-5px}.ui-selectable-helper{position:absolute;z-index:100;border:1px dotted #000}.ui-accordion{width:100%}.ui-accordion .ui-accordion-header{cursor:pointer;position:relative;margin-top:1px;zoom:1}.ui-accordion .ui-accordion-li-fix{display:inline}.ui-accordion .ui-accordion-header-active{border-bottom:0!important}.ui-accordion .ui-accordion-header a{display:block;font-size:1em;padding:.5em .5em .5em .7em}.ui-accordion-icons .ui-accordion-header a{padding-left:2.2em}.ui-accordion .ui-accordion-header .ui-icon{position:absolute;left:.5em;top:50%;margin-top:-8px}.ui-accordion .ui-accordion-content{padding:1em 2.2em;border-top:0;margin-top:-2px;position:relative;top:1px;margin-bottom:2px;overflow:auto;display:none;zoom:1}.ui-accordion .ui-accordion-content-active{display:block}.ui-autocomplete{position:absolute;cursor:default}* html .ui-autocomplete{width:1px}.ui-menu{list-style:none;padding:2px;margin:0;display:block;float:left}.ui-menu .ui-menu{margin-top:-3px}.ui-menu .ui-menu-item{margin:0;padding:0;zoom:1;float:left;clear:left;width:100%}.ui-menu .ui-menu-item a{text-decoration:none;display:block;padding:.2em .4em;line-height:1.5;zoom:1}.ui-menu .ui-menu-item a.ui-state-active,.ui-menu .ui-menu-item a.ui-state-hover{font-weight:400;margin:-1px}.ui-button{display:inline-block;position:relative;padding:0;margin-right:.1em;text-decoration:none!important;cursor:pointer;text-align:center;zoom:1;overflow:visible}.ui-button-icon-only{width:2.2em}button.ui-button-icon-only{width:2.4em}.ui-button-icons-only{width:3.4em}button.ui-button-icons-only{width:3.7em}.ui-button .ui-button-text{display:block;line-height:1.4}.ui-button-icon-only .ui-button-text,.ui-button-icons-only .ui-button-text{padding:.4em;text-indent:-9999999px}.ui-button-text-icon-primary .ui-button-text,.ui-button-text-icons .ui-button-text{padding:.4em 1em .4em 2.1em}.ui-button-text-icon-secondary .ui-button-text,.ui-button-text-icons .ui-button-text{padding:.4em 2.1em .4em 1em}.ui-button-text-icons .ui-button-text{padding-left:2.1em;padding-right:2.1em}input.ui-button{padding:.4em 1em}.ui-button-icon-only .ui-icon,.ui-button-icons-only .ui-icon,.ui-button-text-icon-primary .ui-icon,.ui-button-text-icon-secondary .ui-icon,.ui-button-text-icons .ui-icon{position:absolute;top:50%;margin-top:-8px}.ui-button-icon-only .ui-icon{left:50%;margin-left:-8px}.ui-button-icons-only .ui-button-icon-primary,.ui-button-text-icon-primary .ui-button-icon-primary,.ui-button-text-icons .ui-button-icon-primary{left:.5em}.ui-button-icons-only .ui-button-icon-secondary,.ui-button-text-icon-secondary .ui-button-icon-secondary,.ui-button-text-icons .ui-button-icon-secondary{right:.5em}.ui-button-icons-only .ui-button-icon-secondary,.ui-button-text-icons .ui-button-icon-secondary{right:.5em}.ui-buttonset{margin-right:5px}.ui-buttonset .ui-button{margin:0 3px;background:#fafafa;border:1px solid #d5d5d5;line-height:14px;font-size:11px}button.ui-button::-moz-focus-inner{border:0;padding:0}.ui-dialog{position:absolute;padding:.2em;width:300px;overflow:hidden}.ui-dialog .ui-dialog-titlebar{position:relative}.ui-dialog .ui-dialog-title{float:left;height:38px;font-size:16px;padding:0 12px 0 12px;line-height:38px}.ui-dialog .ui-dialog-titlebar-close{position:absolute;right:6px;top:50%;width:19px;margin:-10px 0 0 0;padding:1px;height:18px}.ui-dialog .ui-dialog-titlebar-close span{display:block;margin:1px}.ui-dialog .ui-dialog-titlebar-close:focus,.ui-dialog .ui-dialog-titlebar-close:hover{padding:1px;background:#fafafa}.ui-dialog .ui-dialog-content{position:relative;border:0;padding:.5em 1em;background:0 0;overflow:auto;zoom:1}.ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset{float:right}.ui-dialog .ui-dialog-buttonpane button{font-size:10px;font-weight:700;text-transform:uppercase;padding:3px 12px 4px 12px;cursor:pointer;font-family:Arial,Helvetica,sans-serif;border:1px solid #d5d5d5;color:#525252;margin:5px}.ui-dialog .ui-resizable-se{width:14px;height:14px;right:3px;bottom:3px}.ui-draggable .ui-dialog-titlebar{cursor:move}.ui-slider{position:relative;text-align:left}.ui-slider .ui-slider-handle{position:absolute;z-index:2;width:16px;height:16px;cursor:default;background:url(../images/ui/handle.png) no-repeat;border:none;cursor:pointer}.ui-slider .ui-slider-range{position:absolute;z-index:1;font-size:.7em;display:block;border:0;background:url(../images/ui/sliderOverlay.png) repeat-x;-moz-border-radius:4px;-webkit-border-radius:4px;-khtml-border-radius:4px;border-radius:4px}.ui-slider-horizontal{height:6px;background:url(../images/ui/sliderBg.png) repeat-x;clear:both;margin-top:10px}.ui-slider-horizontal .ui-slider-handle{top:-5px;margin-left:-.6em}.ui-slider-horizontal .ui-slider-range{top:0;height:100%}.ui-slider-horizontal .ui-slider-range-min{left:0}.ui-slider-horizontal .ui-slider-range-max{right:0}.ui-slider-vertical{width:6px;height:100px;background:url(../images/ui/sliderBgVert.png) repeat-y}.ui-slider-vertical .ui-slider-handle{left:-5px;margin-left:0;margin-bottom:-.6em}.ui-slider-vertical .ui-slider-range{left:0;width:100%;background:url(../images/ui/sliderOverlayVert.png) repeat-y}.ui-slider-vertical .ui-slider-range-min{bottom:0}.ui-slider-vertical .ui-slider-range-max{top:0}.ui-tabs{position:relative;padding:.2em;zoom:1}.ui-tabs .ui-tabs-nav{margin:0;padding:.2em .2em 0}.ui-tabs .ui-tabs-nav li{list-style:none;float:left;position:relative;top:1px;margin:0 .2em 1px 0;border-bottom:0!important;padding:0;white-space:nowrap}.ui-tabs .ui-tabs-nav li a{float:left;padding:.5em 1em;text-decoration:none}.ui-tabs .ui-tabs-nav li.ui-tabs-selected{margin-bottom:0;padding-bottom:1px}.ui-tabs .ui-tabs-nav li.ui-state-disabled a,.ui-tabs .ui-tabs-nav li.ui-state-processing a,.ui-tabs .ui-tabs-nav li.ui-tabs-selected a{cursor:text}.ui-tabs .ui-tabs-nav li a,.ui-tabs.ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-selected a{cursor:pointer}.ui-tabs .ui-tabs-panel{display:block;border-width:0;padding:1em 1.4em;background:0 0}.ui-tabs .ui-tabs-hide{display:none!important}.datepicker{width:58px!important}.ui-datepicker{width:17em;padding:.2em .2em 0;border:1px solid #d5d5d5;background:#fafafa;margin-top:1px;z-index:3;display:none}.ui-datepicker-append{margin-left:10px}.ui-datepicker .ui-datepicker-header{position:relative;padding:.2em 0;border:1px solid #e7e7e7;background:url(../images/leftNavBg.png) repeat-x}.ui-datepicker .ui-datepicker-next,.ui-datepicker .ui-datepicker-prev{position:absolute;top:2px;width:1.8em;height:1.8em}.ui-datepicker .ui-datepicker-next-hover,.ui-datepicker .ui-datepicker-prev-hover{top:1px}.ui-datepicker .ui-datepicker-prev{left:2px}.ui-datepicker .ui-datepicker-next{right:2px}.ui-datepicker .ui-datepicker-prev-hover{left:1px}.ui-datepicker .ui-datepicker-next-hover{right:1px}.ui-datepicker .ui-datepicker-next span,.ui-datepicker .ui-datepicker-prev span{display:block;position:absolute;left:50%;margin-left:-8px;top:50%;margin-top:-8px}.ui-datepicker .ui-datepicker-title{margin:0 2.3em;line-height:1.8em;text-align:center}.ui-datepicker .ui-datepicker-title select{font-size:1em;margin:1px 0}.ui-datepicker select.ui-datepicker-month-year{width:100%}.ui-datepicker select.ui-datepicker-month,.ui-datepicker select.ui-datepicker-year{width:49%}.ui-datepicker table{width:100%;font-size:.9em;border-collapse:collapse;margin:0 0 .4em}.ui-datepicker table .ui-state-default{border:1px solid #d5d5d5}.ui-datepicker table tbody{font-size:11px}.ui-datepicker th{padding:.7em .3em;text-align:center;font-weight:700;border:0}.ui-datepicker td{border:0;padding:1px}.ui-datepicker td a,.ui-datepicker td span{display:block;padding:.2em;text-align:right;text-decoration:none}.ui-datepicker .ui-datepicker-buttonpane{background-image:none;margin:.7em 0 0 0;padding:0 .2em;border-left:0;border-right:0;border-bottom:0}.ui-datepicker .ui-datepicker-buttonpane button{float:right;margin:.5em .2em .4em;cursor:pointer;padding:.2em .6em .3em .6em;width:auto;overflow:visible}.ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current{float:left}.ui-datepicker.ui-datepicker-multi{width:auto}.ui-datepicker-multi .ui-datepicker-group{float:left}.ui-datepicker-multi .ui-datepicker-group table{width:95%;margin:0 auto .4em}.ui-datepicker-multi-2 .ui-datepicker-group{width:50%}.ui-datepicker-multi-3 .ui-datepicker-group{width:33.3%}.ui-datepicker-multi-4 .ui-datepicker-group{width:25%}.ui-datepicker-multi .ui-datepicker-group-last .ui-datepicker-header{border-left-width:0}.ui-datepicker-multi .ui-datepicker-group-middle .ui-datepicker-header{border-left-width:0}.ui-datepicker-multi .ui-datepicker-buttonpane{clear:left}.ui-datepicker-row-break{clear:both;width:100%}.ui-datepicker-rtl{direction:rtl}.ui-datepicker-rtl .ui-datepicker-prev{right:2px;left:auto}.ui-datepicker-rtl .ui-datepicker-next{left:2px;right:auto}.ui-datepicker-rtl .ui-datepicker-prev:hover{right:1px;left:auto}.ui-datepicker-rtl .ui-datepicker-next:hover{left:1px;right:auto}.ui-datepicker-rtl .ui-datepicker-buttonpane{clear:right}.ui-datepicker-rtl .ui-datepicker-buttonpane button{float:left}.ui-datepicker-rtl .ui-datepicker-buttonpane button.ui-datepicker-current{float:right}.ui-datepicker-rtl .ui-datepicker-group{float:right}.ui-datepicker-rtl .ui-datepicker-group-last .ui-datepicker-header{border-right-width:0;border-left-width:1px}.ui-datepicker-rtl .ui-datepicker-group-middle .ui-datepicker-header{border-right-width:0;border-left-width:1px}.ui-progressbar{height:16px;text-align:left;margin-top:5px;background:url(../images/ui/progress.png) repeat-x}.ui-progressbar .ui-progressbar-value{margin:0;height:100%;overflow:hidden;display:block;background:url(../images/ui/progressOverlay.png) repeat-x;border-right:1px solid #3c95d8}.pbar .ui-progressbar-value{display:block!important}.pbar{overflow:hidden;background:url(../images/ui/progress.png) repeat-x}.percent{position:relative;text-align:right;margin-bottom:5px;font-size:11px}.elapsed{position:relative;text-align:right;margin-top:5px;font-size:11px}html{height:100%}* html body{height:100%}body{margin:0;padding:0;background:url(../images/bodyBg.jpg) repeat;font-size:12px;color:#424242;font-family:Arial,Helvetica,sans-serif;line-height:20px;min-height:100%;position:relative}label.error{color:#a73939;font-size:11px;display:block;width:100%;white-space:nowrap;float:none;margin:8px 0 -8px 0;padding:0!important}.selector .error{margin-right:-220px;float:right}.checker label.error,.radio label.error{display:inline;margin:0}.req{margin-left:5px;color:#db6464}.formNote{display:block;text-align:left;font-size:11px;padding-top:5px;color:#939393}div.tagsinput{border:1px solid #ddd;background:#fff;padding:5px;width:100%;overflow-y:auto;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;-ms-box-sizing:border-box;box-sizing:border-box}div.tagsinput span.tag{border:1px solid #a5d24a;display:block;float:left;padding:3px 8px 2px 8px;background:#cde69c;color:#638421;margin:5px 5px 5px 5px}div.tagsinput span.tag a{font-weight:700;color:#82ad2b;font-size:11px;float:right;margin-top:-1px}div.tagsinput input{width:80px;border:none;padding:5px;background:0 0;margin:5px 5px 0 0}div.tagsinput div{display:block;float:left}.tags_clear{clear:both;width:100%;height:0}.not_valid{background:#fbd8db!important;color:#90111a!important}.limiterBox{border:1px solid #ddd;border-top:none;background:#efefef url(../images/leftNavBg.png) repeat-x;padding:4px 6px;font-size:11px;margin-top:1px}::-webkit-input-placeholder{color:#b3b3b3}:-moz-placeholder{color:#b3b3b3}.corner{-webkit-border-bottom-left-radius:0!important;-webkit-border-bottom-right-radius:0!important;-moz-border-radius-bottomleft:0!important;-moz-border-radius-bottomright:0!important}.wrapper{margin:0 5%;clear:both}.img{border:1px solid #d5d5d5}.errorPage p,.leftNav ul li a,.stats ul li span,.ui-dialog .ui-dialog-title,.userLink,h1,h2,h3,h4,h5,h6,ul.tabs li a{font-family:Cuprum,sans-serif;font-weight:400}h1{font-size:24px}h2{font-size:22px}h3{font-size:20px}h4{font-size:18px}h5{font-size:16px}h6{font-size:14px}blockquote{border:1px solid #d5d5d5;margin-top:40px;padding:15px 10px;quotes:"\201C" "\201D";background:#fafafa;text-align:center;font-style:italic;font-size:12px;border-left:4px solid #d5d5d5}blockquote:before{content:open-quote;font-weight:700}blockquote:after{content:close-quote;font-weight:700}.red{color:#b55d5c}.green{color:#2a8827}p{padding:12px 0 0 0}.p12{padding:12px}.pt12{padding-top:12px}.legendLabel span{display:block;margin:0 5px}.legendColorBox{padding-left:10px}.mt40{margin-top:40px}.nomargin{margin:0!important}.nopadding{padding:0!important}.noborder{border:none!important}.nobg{background:0 0!important}.floatleft{display:block;float:left}.floatright{display:block;float:right}.aligncenter{text-align:center}.fix{clear:both}.first{margin-top:25px!important}.inactive{margin-top:0;color:#2b6893}.displayNone{display:none}.wide{width:100%}.currency{text-align:right;font-weight:700}.ml122{margin-left:122px}.w40{width:40%;position:relative}.loginPanel{width:320px;background:#fafafa;border:1px solid #d5d5d5;border-top:0;display:block;height:212px}.loginWrapper{margin:-106px 0 0 -160px;position:absolute;top:50%;left:50%}.loginLogo{position:absolute;width:190px;height:44px;display:block;top:-80px;left:50%;margin-left:-95px}.loginPanel h5{font-weight:400;padding:9px 12px 9px 35px;float:left}.loginPanel label{width:60px}.rememberMe{margin-left:12px}.rememberMe label{padding:4px 12px!important;width:auto}.loginInput{width:200px;float:left}.loginRow{border-top:1px solid #e7e7e7;padding:15px 0;position:relative}.loginRow:first-child{border-top:none}.backTo a:hover{background:#212121}.backTo span{padding:8px 14px 8px 8px;display:block;float:left}.backTo img{margin:13px 2px 11px 14px;float:left;display:block}.backTo a{float:left;color:#eee;font-size:11px;border-right:1px solid #2f2f2f;border-left:1px solid #2f2f2f}.button,button,input[type=button],input[type=reset],input[type=submit]{font-size:10px;font-weight:700;text-transform:uppercase;padding:5px 14px 6px 14px;cursor:pointer;font-family:Arial,Helvetica,sans-serif;line-height:12px}.basicBtn{background:url(../images/ui/basicBtn.png) repeat-x 0 0;border:1px solid #d5d5d5;color:#525252}.basicBtn:hover{background-position:0 -25px;border-color:#c9c9c9}.basicBtn:active{background-position:0 -50px}.blueBtn{background:url(../images/ui/blueBtn.png) repeat-x 0 0;border:1px solid #3581c1;color:#fff}.blueBtn:hover{background-position:0 -25px}.blueBtn:active{background-position:0 -50px}.redBtn{background:url(../images/ui/redBtn.png) repeat-x 0 0;border:1px solid #9d342a;color:#fff}.redBtn:hover{background-position:0 -25px}.redBtn:active{background-position:0 -50px}.seaBtn{background:url(../images/ui/seaBtn.png) repeat-x 0 0;border:1px solid #306873;color:#fff}.seaBtn:hover{background-position:0 -25px}.seaBtn:active{background-position:0 -50px}.blackBtn{background:url(../images/ui/blackBtn.png) repeat-x 0 0;border:1px solid #353535;color:#fff}.blackBtn:hover{background-position:0 -25px}.blackBtn:active{background-position:0 -50px}.greyishBtn{background:url(../images/ui/greyishBtn.png) repeat-x 0 0;border:1px solid #4f5a68;color:#fff}.greyishBtn:hover{background-position:0 -25px}.greyishBtn:active{background-position:0 -50px}.greenBtn{background:url(../images/ui/greenBtn.png) repeat-x 0 0;border:1px solid #418d4f;color:#fff}.greenBtn:hover{background-position:0 -25px}.greenBtn:active{background-position:0 -50px}.btn14{border:1px solid #d5d5d5;background:url(../images/leftNavBg.png) repeat-x 0 0;padding:6px 8px;display:inline-block}.btn14:hover{background:#f6f6f6}.btn14:active{background:#f1f1f1}.btn55{background:#efefef url(../images/middlebg.png) repeat-x 0 0;border:1px solid #d5d5d5;padding:8px 6px 2px 6px;display:inline-block}.btn55:hover{background:#f6f6f6}.btn55:active{background:#f1f1f1}.btn55 span{display:block;padding:5px 5px 0 5px;color:#595858}.btnIconLeft{border:1px solid #d5d5d5;background:url(../images/leftNavBg.png) repeat-x 0 0;display:inline-block;color:#595858}.btnIconLeft:hover{background:#f6f6f6;color:#b55d5c}.btnIconLeft:active{background:#f1f1f1}.btnIconLeft .icon{float:left;border-right:1px solid #d5d5d5;padding:8px}.btnIconLeft span{display:block;float:left;padding:5px 10px;font-weight:700}.pagination{margin:auto;width:auto;text-align:center;margin-top:40px}.pages li.prev{margin-right:15px}.pages li.next{margin-left:15px}.pages li{display:inline;margin:0 2px}.pages li a{height:25px;padding:4px 8px;text-decoration:none;color:#666;font-weight:700;background:url(../images/ui/pagination.png) repeat-x 0 0;border:1px solid #d5d5d5;font-size:11px}.pages li a:hover{background:#efefef}.pages li .active{background-position:0 -26px;color:#fff;border-color:#687282}.pages li .active:hover{background:#687282}.numberLeft,.numberMiddle,.numberTop{text-align:center;background:url(../images/number.png) repeat-x;display:inline-block;padding:1px 5px;color:#fff;-moz-border-radius:2px;-webkit-border-radius:2px;-khtml-border-radius:2px;border-radius:2px;float:right;margin:10px 15px 10px -5px;font-size:11px;line-height:14px}.numberTop{margin:10px 15px 10px -5px;padding:1px 5px!important}.numberMiddle{margin:0;position:absolute;top:-5px;right:-5px;font-size:11px}.numberLeft{margin:0;position:absolute;top:12px;right:8px;font-size:11px;font-family:Arial,Helvetica,sans-serif;float:none;background:url(../images/number.png) repeat-x!important;padding:1px 5px!important}#topNav{height:36px;display:block}.fixed{position:fixed;background-color:#262b2f;width:100%;color:#eee;border-bottom:1px solid #fff;z-index:999}.welcome{float:left}.welcome img{float:left;margin:8px 8px 8px 0}.welcome span{padding:8px 5px;display:block;white-space:nowrap;float:left;font-size:11px}.userNav{float:right;z-index:6000;position:relative;font-size:11px}.userNav .lastNav{width:2px;height:36px;background:url(../images/navSep.png) repeat-y;position:absolute;top:0;right:0}.userNav ul{margin-right:2px}.userNav ul li{display:inline;float:left;position:relative;cursor:pointer;border-right:1px solid #2f2f2f}.userNav ul li:first-child{border-left:1px solid #2f2f2f}.userNav ul li a{color:#eee;text-decoration:none;display:block;float:left}.selected,.userNav ul li:hover{background:#212121}.userNav ul li span{display:block;padding:8px 14px 8px 8px;float:left}.userNav ul li img{float:left;display:block;padding:13px 2px 11px 14px}.userNav ul li ul{position:absolute;left:-1px;display:none;top:35px;margin-top:0;background:#2f2f2f;padding:0 1px 1px 1px;border:1px solid #1d1d1d;z-index:100}.userNav ul li ul li{display:block;float:none;border-top:1px solid #2f2f2f;background:#212121;border-right:none;border-bottom:1px solid #141414}.userNav ul li ul li:first-child{border-left:none!important}.userNav ul li ul li a{width:100px;padding:6px 10px 7px 36px;font-size:11px;text-transform:none;color:#c5c5c5;font-weight:400;background-color:none;float:none}.userNav ul li ul li a:hover{background-color:none;font-weight:400;color:#a4a4a4}.userNav ul li ul li:hover{background:#1d1d1d!important}.sAdd{background:url(../images/icons/topnav/subAdd.png) no-repeat 15px 13px}.sInbox{background:url(../images/icons/topnav/subInbox.png) no-repeat 14px 12px}.sOutbox{background:url(../images/icons/topnav/subOutbox.png) no-repeat 14px 11px}.sTrash{background:url(../images/icons/topnav/subTrash.png) no-repeat 14px 12px}#header{height:106px;clear:both}.logo{float:left;margin-top:30px}.middleNav{float:right;margin-right:1px}.middleNav ul{margin-top:25px}.middleNav ul li{height:55px;text-align:center;display:block;float:left;margin-left:25px;position:relative;min-width:64px}.middleNav ul li:first-child{margin:0}.middleNav ul li a{display:block;border:1px solid #d5d5d5;background:url(../images/middlebg.png) repeat-x 0 0;-moz-border-radius:2px;-webkit-border-radius:2px;-khtml-border-radius:2px;border-radius:2px;color:#595858;font-size:12px;position:relative;-moz-box-shadow:0 2px 1px #fff;-webkit-box-shadow:0 2px 1px #fff;box-shadow:0 2px 1px #fff}.middleNav ul li a span{display:block;padding:34px 10px 0 10px}.middleNav ul li a span i{margin-top:-26px;margin-bottom:4px}.middleNav ul li.iStat a span{background:url(../images/icons/middlenav/graph.png) no-repeat 50% 8px}.middleNav ul li.iTransactions a span{background:url(../images/icons/middlenav/transfer.png) no-repeat 50% 8px}.middleNav ul li.iPlugin a span{background:url(../images/icons/middlenav/electroPlug.png) no-repeat 50% 8px}.middleNav ul li.iMegaphone a span{background:url(../images/icons/middlenav/megaphone.png) no-repeat 50% 8px}.middleNav ul li a:hover{background:#f6f6f6}.middleNav ul li a:active{background:#f1f1f1}.leftNav{width:212px;max-width:36%;margin-top:-1px;float:left;margin-bottom:80px;margin-right:41px}.leftNav .last{border-bottom:none}.leftNav ul li{position:relative}.leftNav ul li a{color:#494949;font-size:15px;display:block;background:#efefef url(../images/leftNavBg.png) repeat-x 0 0;border:1px solid #d5d5d5;margin-top:1px}.leftNav ul li a.active,.leftNav ul li a:hover{background:url(../images/darkBg.jpg) repeat-x;color:#fff;border:1px solid #3c4049}.leftNav ul li a span{padding:9px 0 9px 0;display:block}.leftNav ul li a span i{margin:-3px 10px}.leftNav ul li.home a span{background:url(../images/icons/dark/home.png) no-repeat 10px}.leftNav ul li.transactions a span{background:url(../images/icons/dark/transfer.png) no-repeat 10px}.leftNav ul li.dash a span{background-image:url(../images/icons/dark/download.png)}.leftNav ul li.forms a span{background-image:url(../images/icons/dark/pencil.png)}.leftNav ul li.gallery a span{background-image:url(../images/icons/dark/preview.png)}.leftNav ul li.typo span{background-image:url(../images/icons/dark/create.png)}.leftNav ul li.tables a span{background-image:url(../images/icons/dark/frames.png)}.leftNav ul li.cal a span{background-image:url(../images/icons/dark/dayCalendar.png)}.leftNav ul li.errors a span{background-image:url(../images/icons/dark/alert.png)}.leftNav ul li.files a span{background-image:url(../images/icons/dark/files.png)}.leftNav ul li.login a span{background-image:url(../images/icons/dark/user.png)}.leftNav ul li.widgets a span{background-image:url(../images/icons/dark/full.png)}ul.sub{border:2px solid #3c4049;border-top:none;background:url(../images/leftNavSub.png) repeat}ul.sub li{border-bottom:1px dotted #d5d5d5;padding:1px}ul.sub li a{background:url(../images/arrow.gif) no-repeat 8px 16px;border:none;font-family:Arial,Helvetica,sans-serif;color:#494949;font-size:11px;padding:8px 10px 8px 18px}.sub li a:active,ul.sub li a:hover{font-style:normal;border:none;color:#676767;background:url(../images/arrow.gif) no-repeat 8px 16px}ul.sub li ul{border:none;border-top:1px solid #c9c9c9}ul.sub li ul li{padding-left:10px}.stats{margin-top:25px}.stats ul li{display:block;float:left;margin-left:5%;vertical-align:top;width:21.2%}.stats ul li:first-child{margin:0}.stats ul li span{color:#424242;font-size:16px;display:block;vertical-align:middle;white-space:normal}.count{font-size:26px;height:40px;display:inline-block;float:left;line-height:41px;padding:0 10px;-moz-box-shadow:0 1px 0 #fff;-webkit-box-shadow:0 1px 0 #fff;box-shadow:0 1px 0 #fff;margin-right:10px}.stats a.blue{background:url(../images/count/blue.png) repeat-x 0 0;border:1px solid #2e6590;color:#f7f7f7}.stats a.blue:hover{background-position:0 -41px}.stats a.blue:active{background-position:0 -82px}.stats a.grey{background:#efefef url(../images/leftNavBg.png) repeat-x;border:1px solid #d5d5d5;color:#b55d5c}.stats a.grey:hover{background:#f6f6f6}.stats a.grey:active{background:#f1f1f1}.stats a.green{background:url(../images/count/green.png) repeat-x;border:1px solid #19710e;color:#f7f7f7}.stats a.green:hover{background-position:0 -41px}.stats a.green:active{background-position:0 -82px}.stats a.red{background:#efefef url(../images/count/red.png) repeat-x;border:1px solid #7b2f2f;color:#f7f7f7}.stats a.red:hover{background-position:0 -41px}.stats a.red:active{background-position:0 -82px}.fc-button-prev .fc-button-content{width:10px;background:url(../images/leftArrow.png) no-repeat 15px 13px}.fc-button-next .fc-button-content{width:10px;background:url(../images/rightArrow.png) no-repeat 15px 13px}.widget{margin-top:40px;border:1px solid #d5d5d5;display:block;background:#fafafa;clear:both;border-top:none}.widgetS{margin-top:40px;border:1px solid #d5d5d5;display:block;background:#fafafa;border-top:none;min-width:25%;float:left;margin-right:40px}.head{background:#efefef url(../images/leftNavBg.png) repeat-x;height:38px;border-top:1px solid #d5d5d5;border-bottom:1px solid #d5d5d5;position:relative}.table h5,.widget .head h5{font-weight:400;padding:9px 12px 9px 35px;float:left}.widget .body{padding:12px 14px}.accordion-close h5,.widget .normal h5{background:url(../images/aNormal.png) no-repeat 15px 15px;padding:9px 12px 9px 32px!important}.accordion-open h5,.widget .inactive h5{background:url(../images/aInactive.png) no-repeat 12px 17px;padding:9px 12px 9px 32px!important}.widget .num{float:right;display:inline-block;text-align:center;margin:9px 9px 0 0;font-size:11px}.widget .num span{margin-right:10px}.widget .num a{background:url(../images/ui/numDataBg.png) repeat-x;height:19px;padding:2px 5px;color:#fefefe}.widget .num a.blueNum{background-position:0 0;border:1px solid #606873}.widget .num a.blueNum:hover{background-position:0 -19px}.widget .num a.blueNum:active{background-position:0 -38px}.widget .num a.redNum{background-position:0 -57px;border:1px solid #9d382f}.widget .num a.redNum:hover{background-position:0 -76px}.widget .num a.redNum:active{background-position:0 -95px}.widget .num a.greenNum{background-position:0 -114px;border:1px solid #218516}.widget .num a.greenNum:hover{background-position:0 -133px}.widget .num a.greenNum:active{background-position:0 -152px}.widget .loader{float:right;margin:14px 12px 0 0}.userLink{font-size:16px;padding-top:3px;display:block;margin-left:25px;white-space:nowrap}.userWidget{padding:6px 12px 0 12px;display:block;float:left}.inactive,.normal{cursor:pointer}.accordion-close,.normal{border-bottom:none}.standalone{float:left;width:300px;margin-left:40px}.standalone:first-child{margin-left:0}.pics{padding-bottom:14px;margin:auto;padding:0 6px 14px 6px;text-align:center}.pics ul li{display:inline-block;height:102px;margin:16px 6px 0 6px;border:1px solid #d5d5d5;position:relative}.pics ul li:hover{border-color:#bbc1c9}.pics .actions{background:#000;opacity:.8;position:absolute;bottom:0;right:0;display:none}.pics .actions a{color:#fff;font-size:11px;display:block;padding:3px 4px;float:left}.pics .actions a:first-child{padding-right:0}ul.tabs{background:url(../images/leftNavBg.png) repeat-x;height:38px;border-bottom:1px solid #d5d5d5;border-top:1px solid #d5d5d5}ul.tabs li{float:left;height:38px;line-height:39px;border-left:none;overflow:hidden;position:relative;border-right:1px solid #d5d5d5;font-size:15px}ul.tabs li a{text-decoration:none;display:block;padding:0 12px;outline:0;color:#424242}ul.tabs li a:hover{color:#797979}html ul.tabs li.activeTab{background-color:#fafafa;height:39px}html ul.tabs li.activeTab a{color:#797979}.tab_container{overflow:hidden;clear:both;float:left;width:100%}.tab_content{padding:10px 12px}.tabsRight{position:relative}.tabsRight ul.tabs{float:right;background:url(../images/leftNavBg.png) repeat-x;height:38px;border-bottom:1px solid #d5d5d5;position:absolute;top:0;right:0}.tabsRight ul.tabs li{border-left:1px solid #d5d5d5;border-right:none}.tabsRight ul.tabs li.activeTab{background-color:#fafafa;height:38px}.twoOne{width:50%}.breadCrumb,.btn14,.btn55,.content .title,.count,.customfile,.earnings,.errorPage,.leftNav ul li a,.listData .cNote,.loginPanel,.pages li a,.table,.widget,.widget .num a,a.count1{-moz-border-radius:2px;-webkit-border-radius:2px;-khtml-border-radius:2px;border-radius:2px}.widgets{clear:both}.widgets .left{float:left;width:48%;margin-right:4%}.widgets .right{float:right;width:48%}.content{padding-bottom:80px;overflow:hidden}.content .title{background:url(../images/darkBg.jpg) repeat-x;height:36px;-moz-box-shadow:0 1px 0 #fff;-webkit-box-shadow:0 1px 0 #fff;box-shadow:0 1px 0 #fff}.content .title h5{float:left;color:#fafafa;font-weight:400;display:block;padding:7px 15px}.supTicket{background:url(../images/linesSep.png) 0 0 repeat-x;padding:12px 12px 15px 12px}.supTicket .issueType{color:#515e70;clear:both;font-weight:700;background:url(../images/dashed.png) repeat-x 0}.supTicket .issueType .issueInfo{float:left;display:block;background:#fafafa;padding-right:5px}.supTicket .issueType .issueNum{float:right;display:block;background:#fafafa;padding-left:5px;padding-right:1px}.issueSummary{clear:both;padding-top:14px}.issueSummary img{border:1px solid #d5d5d5}.ticketInfo ul{float:left;width:100%;margin-bottom:-6px}.ticketInfo ul li{width:50%;margin-top:-2px;display:inline-block;float:left;margin-bottom:6px;padding:0}.ticketInfo ul li.even{text-align:right}.ticketInfo{margin-top:-3px;margin-bottom:-11px;margin-left:50px}.userSummary{background:url(../images/linesSep.png) 0 100% repeat-x}.userSummary ul li{width:127px;display:block;float:left;margin-bottom:12px;margin-top:-1px}.userSummary ul li.even{text-align:right}.userSummary .infoLeft{width:153px;float:left}.userSummary .infoLeft div,.userSummary .infoRight div{padding-top:12px}.userSummary .infoLeft div:first-child,.userSummary .infoRight div:first-child{padding:0}.userSummary .infoRight{width:153px;float:right;text-align:right}.userAlt{padding:0 12px;background:url(../images/leftNavBg.png) repeat-x}.userAlt img{float:left;display:block;margin:4px 8px 0 0}.userEmail{display:block;white-space:nowrap}.botRow span{float:left;display:block;margin-right:10px}#eq span{height:120px;float:left;margin-right:30px;display:block}.searchWidget{position:relative;margin-top:40px}.searchWidget input[type=text]{background:#fafafa;border:1px solid #d5d5d5;padding:10px;width:100%;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;-ms-box-sizing:border-box;box-sizing:border-box}.searchWidget input[type=submit]{background:url(../images/searchBtn.png) no-repeat 0 0;position:absolute;top:0;right:0;border:none;width:36px;height:36px}.webStatsLink{font-size:16px;color:#b55d5c;font-weight:700}.statMinus,.statPlus{padding-left:12px;font-size:12px}.statPlus{color:#549332;background:url(../images/topArrow.png) no-repeat 0 3px}.statMinus{color:#b55d5c;background:url(../images/botArrow.png) no-repeat 0 3px}.menu_body{display:none;padding:12px 14px}.acc .head{margin-bottom:-1px;cursor:pointer}.acc .head h5{padding:9px 14px}.autoUpdate,.bars,.chart{height:220px;z-index:90;margin:10px 0 0 0;max-width:100%}.pieWidget{width:100%;height:316px;margin:0 auto}#footer{clear:both;background:url(../images/topNav.jpg) repeat;width:100%;color:#eee;margin-top:42px;position:absolute;bottom:0}#footer span{color:#696969;padding:9px 5px;display:block;font-size:11px}#footer span a{color:#eee}.tableStatic thead td{padding:3px 0 2px 0;text-align:center;border-left:1px solid #d5d5d5;background:#efefef url(../images/leftNavBg.png) repeat-x;border-bottom:1px solid #d5d5d5;font-size:11px;color:#878787}.tableStatic thead td:first-child{border-left:none}.tableStatic tbody tr{border-top:1px solid #e7e7e7}.tableStatic tbody tr:nth-child(even){background-color:#f5f5f5}.tableStatic tbody td{border-left:1px solid #e7e7e7;padding:8px 10px;vertical-align:middle}.tableStatic tbody td:first-child{border-left:none}.mainForm label{margin-right:15px;display:block;float:left;padding:4px 10px}.datepicker{width:58px!important;cursor:pointer}.colorpick{width:58px!important;float:left;cursor:pointer}.pick{width:16px;height:16px;float:left;background:url(../images/color.png) no-repeat 0;margin:2px 5px;cursor:pointer;padding:4px 0!important}.colorP{position:relative;width:58px}.multiple{width:100%;height:200px;padding:5px;border:1px solid #d5d5d5}.sliderSpecs label{padding:0!important;font-size:11px;line-height:14px}.sliderSpecs input{float:left;width:auto!important;background:0 0!important;border:0!important;font-weight:700;color:#3a6fa5;padding:0!important;margin-left:10px}.moreFields ul li{float:left;width:8%;margin:0}.moreFields ul li.sep{padding:3px 5px 3px 6px;display:block;margin:0;width:auto;color:#d5d5d5}.moreFields ul li span{display:block;padding:3px 12px;white-space:nowrap}.moreFields ul li div.selector span{padding:0}.itemDisabled{color:#b7b7b7}.rowElem{clear:both;border-top:1px solid #e7e7e7;padding:10px 16px;position:relative}.formRight{float:right;width:76%;margin:12px 0;display:block;position:relative}.formRight label,.loginRow label{cursor:pointer}.formBottom{margin:12px 12px 12px 0}.rowElem>label{padding:15px 0;width:14%}.rowElem .topLabel{padding:5px 12px 12px 0;width:100%}#valid input{position:relative}.mainForm input[type=email],.mainForm input[type=password],.mainForm input[type=text],.mainForm textarea{background:#fff;width:100%;border:1px solid #d5d5d5;padding:5px;font-size:11px;font-family:Arial,Helvetica,sans-serif;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;-ms-box-sizing:border-box;box-sizing:border-box}.mainForm input[type=password]:hover,.mainForm input[type=text]:hover,.mainForm textarea:hover{background:#fcfcfc;border:1px solid #d1d1d1}.mainForm input[type=password]:focus,.mainForm input[type=text]:focus,.mainForm textarea:focus{border:1px solid #bbc1c9;background:#fff}.submitForm{float:right;margin:1px 16px 22px 16px}div.selector{position:relative;height:26px;background:url(../images/chosenSelect.png) repeat-x;float:left;width:190px;position:relative;padding-left:10px;border:1px solid #d5d5d5}div.selector span{width:190px;cursor:pointer;position:absolute;right:-1px;height:26px;background:url(../images/forms/select_right.png) no-repeat center right;top:0;line-height:27px;font-size:11px}div.selector select{width:202px;cursor:pointer;font-size:12px;position:absolute;height:26px;top:2px;left:-1px}li div.selector{padding-left:13px}li div.selector span{top:-3px}.dataTables_length div.selector{width:45px;float:left;height:20px;padding-left:8px}.dataTables_length div.selector span{width:45px;height:22px;background:url(../images/forms/select_right_datatable.png) no-repeat center right;line-height:22px;top:-1px}.dataTables_length div.selector select{width:65px;left:-5px;height:22px}div.checker{width:15px;height:15px;position:relative;float:left;margin-top:6px}div.checker input{width:15px;height:15px;opacity:0;display:inline-block;background:0 0}div.checker span{background:transparent url(../images/forms/checkbox.png) no-repeat 0 0;vertical-align:middle;height:15px;width:15px;display:-moz-inline-box;display:inline-block;text-align:center}div.checker span.checked{background-position:center bottom}div.radio{width:18px;height:18px;position:relative;float:left;margin-top:5px}div.radio input{opacity:0;text-align:center;display:inline-block;background:0 0;width:18px;height:18px}div.radio span{background:transparent url(../images/forms/radio.png) no-repeat 0 0;vertical-align:middle;height:15px;width:15px;display:block;display:-moz-inline-box;display:inline-block;text-align:center}div.radio span.checked{background-position:center bottom}div.uploader{width:240px;position:relative;overflow:hidden;border:1px solid #d5d5d5;background:#fff;padding:2px 2px 2px 8px}div.uploader span.action{width:22px;background:#fff url(../images/addFiles.png) no-repeat 0 0;height:22px;font-size:11px;font-weight:700;cursor:pointer;float:right;text-indent:-9999px;display:inline;overflow:hidden;cursor:pointer}div.uploader:hover span.action{background-position:0 -27px}div.uploader:active span.action{background-position:0 -54px}div.uploader span.filename{color:#777;max-width:200px;font-size:11px;line-height:22px;float:left;display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;cursor:default}div.uploader input{width:266px;opacity:0;position:absolute;top:0;right:0;bottom:0;float:right;height:26px;border:none;cursor:pointer}.uploader{display:-moz-inline-box;display:inline-block;vertical-align:middle;zoom:1}.list .legend{display:block;font-weight:700;padding-bottom:4px}.list ul li{padding:0 0 0 15px}.plusBlue li{background:url(../images/icons/lists/plusBlue.png) no-repeat 0 7px}.plusRed li{background:url(../images/icons/lists/plusRed.png) no-repeat 0 7px}.plusGrey li{background:url(../images/icons/lists/plusGrey.png) no-repeat 0 7px}.plusGreen li{background:url(../images/icons/lists/plusGreen.png) no-repeat 0 7px}.tipBlue ul li{background:url(../images/icons/lists/tipBlue.png) no-repeat 0 6px}.tipRed ul li{background:url(../images/icons/lists/tipRed.png) no-repeat 0 6px}.tipGrey ul li{background:url(../images/icons/lists/tipGrey.png) no-repeat 0 6px}.tipGreen ul li{background:url(../images/icons/lists/tipGreen.png) no-repeat 0 6px}.arrowBlue ul li{background:url(../images/icons/lists/arrowBlue.png) no-repeat 1px 6px}.arrowRed ul li{background:url(../images/icons/lists/arrowRed.png) no-repeat 1px 6px}.arrowGrey ul li{background:url(../images/icons/lists/arrowGrey.png) no-repeat 1px 6px}.arrowGreen ul li{background:url(../images/icons/lists/arrowGreen.png) no-repeat 1px 6px}.arrow2Blue ul li{background:url(../images/icons/lists/arrow2Blue.png) no-repeat 1px 6px}.arrow2Red ul li{background:url(../images/icons/lists/arrow2Red.png) no-repeat 1px 6px}.arrow2Grey ul li{background:url(../images/icons/lists/arrow2Grey.png) no-repeat 1px 6px}.arrow2Green ul li{background:url(../images/icons/lists/arrow2Green.png) no-repeat 1px 6px}.tipsy{padding:4px;font-size:10px;opacity:.8;background-repeat:no-repeat;background-image:url(../images/tipsy.gif)}.tipsy-inner{padding:2px 8px 2px 8px;background-color:#000;color:#fff;max-width:200px;text-align:center}.tipsy-inner{-moz-border-radius:3px;-webkit-border-radius:3px}.tipsy-north{background-position:top center}.tipsy-south{background-position:bottom center}.tipsy-east{background-position:right center}.tipsy-west{background-position:left center}.nNote{cursor:pointer;clear:both;margin:20px 0 20px 0}.nNote strong{margin-right:5px}.nNote p{font-size:11px;padding:10px 25px 10px 54px;margin:0;color:#565656}.nMessage p{font-size:11px}.nWarning{background:#ffe9ad url(../images/icons/notifications/error.png) no-repeat 15px center;border:1px solid #eac572;color:#826200}.nSuccess{background:#effeb9 url(../images/icons/notifications/accept.png) no-repeat 15px center;border:1px solid #c1d779;color:#3c5a01}.nFailure{background:#fccac1 url(../images/icons/notifications/exclamation.png) no-repeat 15px center;border:1px solid #e18b7c;color:#ac260f}.nInformation{background:#d1e4f3 url(../images/icons/notifications/information.png) no-repeat 15px center;border:1px solid #99c4ea;color:#235685}.nLightbulb{background:#fef0cb url(../images/icons/notifications/lightbulb.png) no-repeat 15px center;border:1px solid #d3a350;color:#835f21}.nMessages{background:#9ddfff url(../images/icons/notifications/email.png) no-repeat 15px center;border:1px solid #42b4ff;color:#835f21}.table{margin-top:40px;border:1px solid #d5d5d5;border-top:none}.headTitle{background:#efefef url(../images/leftNavBg.png) repeat-x;height:37px;border-bottom:1px solid #d5d5d5}.ui-spinner{width:10em;display:block;position:relative;overflow:hidden;border:1px solid #d5d5d5;background:url(../images/forms/spinnerBg.png) repeat-x top left!important;height:25px;padding:0 6px}.ui-spinner-disabled{background:#f4f4f4;color:#ccc}.ui-spinner input.ui-spinner-box{border:none!important;background:0 0!important;padding:6px 0}.ui-spinner-down,.ui-spinner-up{width:18px;padding:0;margin:0;z-index:100;position:absolute;right:0;cursor:default;border:none}.ui-spinner-up{background:url(../images/forms/spinnerTop.png) no-repeat;height:13px;top:0}.ui-spinner-down{height:12px;bottom:0;background:url(../images/forms/spinnerBottom.png) no-repeat}.ui-spinner-list,.ui-spinner-listitem{margin:0;padding:0;font-size:11px}.ui-spinner ul li,.ui-spinner-data{line-height:25px;height:25px}div.jGrowl{z-index:9999;color:#fff;font-size:12px}div.ie6.top-right{right:auto;bottom:auto;left:expression( ( 0 - jGrowl.offsetWidth + ( document.documentElement.clientWidth ? document.documentElement.clientWidth : document.body.clientWidth ) + ( ignoreMe2 = document.documentElement.scrollLeft ? document.documentElement.scrollLeft : document.body.scrollLeft ) ) + 'px' );top:expression( ( 0 + ( ignoreMe = document.documentElement.scrollTop ? document.documentElement.scrollTop : document.body.scrollTop ) ) + 'px' )}div.ie6.top-left{left:expression( ( 0 + ( ignoreMe2 = document.documentElement.scrollLeft ? document.documentElement.scrollLeft : document.body.scrollLeft ) ) + 'px' );top:expression( ( 0 + ( ignoreMe = document.documentElement.scrollTop ? document.documentElement.scrollTop : document.body.scrollTop ) ) + 'px' )}div.ie6.bottom-right{left:expression( ( 0 - jGrowl.offsetWidth + ( document.documentElement.clientWidth ? document.documentElement.clientWidth : document.body.clientWidth ) + ( ignoreMe2 = document.documentElement.scrollLeft ? document.documentElement.scrollLeft : document.body.scrollLeft ) ) + 'px' );top:expression( ( 0 - jGrowl.offsetHeight + ( document.documentElement.clientHeight ? document.documentElement.clientHeight : document.body.clientHeight ) + ( ignoreMe = document.documentElement.scrollTop ? document.documentElement.scrollTop : document.body.scrollTop ) ) + 'px' )}div.ie6.bottom-left{left:expression( ( 0 + ( ignoreMe2 = document.documentElement.scrollLeft ? document.documentElement.scrollLeft : document.body.scrollLeft ) ) + 'px' );top:expression( ( 0 - jGrowl.offsetHeight + ( document.documentElement.clientHeight ? document.documentElement.clientHeight : document.body.clientHeight ) + ( ignoreMe = document.documentElement.scrollTop ? document.documentElement.scrollTop : document.body.scrollTop ) ) + 'px' )}div.ie6.center{left:expression( ( 0 + ( ignoreMe2 = document.documentElement.scrollLeft ? document.documentElement.scrollLeft : document.body.scrollLeft ) ) + 'px' );top:expression( ( 0 + ( ignoreMe = document.documentElement.scrollTop ? document.documentElement.scrollTop : document.body.scrollTop ) ) + 'px' );width:100%}div.jGrowl{position:absolute}body>div.jGrowl{position:fixed}div.jGrowl.top-left{left:0;top:0}div.jGrowl.top-right{right:0;top:36px}div.jGrowl.bottom-left{left:0;bottom:0}div.jGrowl.bottom-right{right:0;bottom:0}div.jGrowl.center{top:0;width:50%;left:25%}div.center div.jGrowl-closer,div.center div.jGrowl-notification{margin-left:auto;margin-right:auto}div.jGrowl div.jGrowl-closer,div.jGrowl div.jGrowl-notification{background-color:#000;opacity:.85;zoom:1;width:235px;padding:10px;margin-top:5px;margin-bottom:5px;font-family:Tahoma,Arial,Helvetica,sans-serif;font-size:1em;text-align:left;display:none}div.jGrowl div.jGrowl-notification{min-height:40px}div.jGrowl div.jGrowl-closer,div.jGrowl div.jGrowl-notification{margin:10px}div.jGrowl div.jGrowl-notification div.jGrowl-header{font-weight:700;font-size:.85em}div.jGrowl div.jGrowl-notification div.jGrowl-close{z-index:99;float:right;font-weight:700;font-size:1em;cursor:pointer}div.jGrowl div.jGrowl-closer{padding-top:4px;padding-bottom:4px;cursor:pointer;font-size:.9em;font-weight:700;text-align:center}@media print{div.jGrowl{display:none}}#toTop{display:none;text-decoration:none;position:fixed;bottom:10px;right:10px;overflow:hidden;width:21px;height:21px;border:none;text-indent:-999px;background:url(../images/ui.totop.png) no-repeat left top}#toTopHover{background:url(../images/ui.totop.png) no-repeat left -22px;width:21px;height:21px;display:block;overflow:hidden;float:left;opacity:0;-moz-opacity:0}#toTop:active,#toTop:focus{outline:0}.listNav{margin:0 0 10px}.ln-letters{overflow:hidden;width:100%;margin-top:-1px;text-align:center}.ln-letters a{font-size:11px;display:inline-block;padding:4px 1%;border:1px solid #d5d5d5;margin-right:-1px;text-decoration:none;background:#efefef url(../images/leftNavBg.png) repeat-x}ul.listData{float:right;text-align:right;margin-top:-1px;font-size:11px}ul.listData li{display:inline-block;padding:0 6px 1px 6px!important;border:none!important;margin-left:6px}.listData .cNote{background:#fafafa;display:block;padding:0 6px;border:1px solid #d5d5d5;color:#878787}.ln-letters a.ln-selected,.ln-letters a:hover{background:#eaeaea}.ln-letters a.ln-disabled{color:#ccc}.ln-letter-count{text-align:center;font-size:.8em;line-height:1;margin-bottom:3px;color:#369}#myList>li{padding:8px 0 8px 12px;border-top:1px solid #ebebeb}#myList>li:hover{background:#fff}#myList>li:first-child{padding-top:8px}.SRC_Wrap{height:auto;font-size:12px}.SRC_Title{text-align:center;color:#555;border-bottom:2px solid #999;font-size:14px;font-family:Verdana,Geneva,sans-serif;padding:5px;font-weight:700}.SRC_Line{width:100%;background-color:#fafafa;min-height:28px;line-height:28px}.SRC_Line:nth-child(even){background-color:#f5f5f5}.SRC_NumBox{width:5%;float:left}.SRC_Num{font-family:Verdana,Geneva,sans-serif;font-size:12px;text-align:right;color:#555;font-weight:500;padding-right:2px;width:100%;height:auto;min-height:28px;line-height:28px}.SRC_CodeContent{white-space:pre-wrap;border-left:1px solid #d5d5d5;font-size:12px;padding-left:6px;font-family:"Courier New",Courier,monospace;margin:0;min-height:28px;line-height:28px}.SRC_NumContent{text-align:right;margin-right:4px;color:#555}.SRC_CodeBox{float:left;width:95%}.SC_blue{color:#00f}.SC_grey{color:grey}.SC_navy{color:navy}.SC_green{color:green}.SC_orange{color:#930}.SC_red{color:red}.SC_teal{color:teal}.SC_gold{color:#fc0}.SC_pink{color:#ff68a4}.SC_bold{font-weight:700}.module:after{clear:both;content:".";display:block;height:0;visibility:hidden}* html .module{height:1%;overflow:visible}.breadCrumbHolder.module{border:solid 1px #d5d5d5;background:#fafafa;margin-top:20px}.breadCrumb{float:left;display:block;height:21px;overflow:hidden;width:100%;padding:5px}.breadCrumb ul{margin:0;padding:0;height:21px;display:block}.breadCrumb ul li{display:block;float:left;position:relative;height:21px;overflow:hidden;line-height:21px;margin:0 6px 0 0;padding:0 12px 0 2px;font-size:.9167em;background:url(../images/Chevron.gif) no-repeat 100% 0}.breadCrumb ul li div.chevronOverlay{position:absolute;right:0;top:0;z-index:2}.breadCrumb ul li span{display:block;overflow:hidden}.breadCrumb ul li a{display:block;position:relative;height:21px;line-height:21px;overflow:hidden;float:left}.breadCrumb ul li.firstB a{height:16px!important;text-indent:-1000em;width:16px;padding:0;margin-top:2px;overflow:hidden;background:url(../images/IconHome.gif) no-repeat 0 0}.breadCrumb ul li.firstB a:hover{background-position:0 -16px}.breadCrumb ul li.lastB{background:0 0;margin-right:0;padding-right:0}.chevronOverlay{display:none;background:url(../images/ChevronOverlay.png) no-repeat 100% 0;width:13px;height:20px}.inputContainer{position:relative;float:left}.formError{position:absolute;top:300px;left:280px;display:block;z-index:500;cursor:pointer}.ajaxSubmit{padding:20px;background:#55ea55;border:1px solid #999;display:none}.formError .formErrorContent{background:#202020;position:relative;z-index:5001;color:#fff;width:160px;font-size:11px;border:1px solid #000;padding:4px 10px 4px 10px;border-radius:2px;-moz-border-radius:2px;-webkit-border-radius:2px}.greenPopup .formErrorContent{background:#33be40}.blackPopup .formErrorContent{background:#393939;color:#fff}.formError .formErrorArrow{width:15px;margin:-2px 0 0 13px;position:relative;z-index:5006}.formError .formErrorArrowBottom{box-shadow:none;-moz-box-shadow:none;-webkit-box-shadow:none;margin:0 0 0 12px;top:2px}.formError .formErrorArrow div{font-size:0;height:1px;background:#202020;margin:0 auto;line-height:0;font-size:0;display:block}.formError .formErrorArrowBottom div{box-shadow:none;-moz-box-shadow:none;-webkit-box-shadow:none}.greenPopup .formErrorArrow div{background:#33be40}.blackPopup .formErrorArrow div{background:#393939;color:#fff}.formError .formErrorArrow .line10{width:15px;border:none}.formError .formErrorArrow .line9{width:13px;border:none}.formError .formErrorArrow .line8{width:11px}.formError .formErrorArrow .line7{width:9px}.formError .formErrorArrow .line6{width:7px}.formError .formErrorArrow .line5{width:5px}.formError .formErrorArrow .line4{width:3px}.formError .formErrorArrow .line3{width:1px;border-left:2px solid #ddd;border-right:2px solid #ddd;border-bottom:0 solid #ddd}.formError .formErrorArrow .line2{width:3px;border:none;background:#ddd}.formError .formErrorArrow .line1{width:1px;border:none;background:#ddd}.colorpicker{width:356px;height:176px;overflow:hidden;position:absolute;background:url(../images/colorPicker/colorpicker_background.png);font-family:Arial,Helvetica,sans-serif;display:none}.colorpicker_color{width:150px;height:150px;left:14px;top:13px;position:absolute;background:red;overflow:hidden;cursor:crosshair}.colorpicker_color div{position:absolute;top:0;left:0;width:150px;height:150px;background:url(../images/colorPicker/colorpicker_overlay.png)}.colorpicker_color div div{position:absolute;top:0;left:0;width:11px;height:11px;overflow:hidden;background:url(../images/colorPicker/colorpicker_select.gif);margin:-5px 0 0 -5px}.colorpicker_hue{position:absolute;top:13px;left:171px;width:35px;height:150px;cursor:n-resize}.colorpicker_hue div{position:absolute;width:35px;height:9px;overflow:hidden;background:url(../images/colorPicker/colorpicker_indic.gif) left top;margin:-4px 0 0 0;left:0}.colorpicker_new_color{position:absolute;width:60px;height:30px;left:213px;top:13px;background:red}.colorpicker_current_color{position:absolute;width:60px;height:30px;left:283px;top:13px;background:red}.colorpicker input{background-color:transparent;border:1px solid transparent;position:absolute;font-size:10px;font-family:Arial,Helvetica,sans-serif;color:#898989;top:4px;right:11px;text-align:right;margin:0;padding:0;height:11px}.colorpicker_hex{position:absolute;width:72px;height:22px;background:url(../images/colorPicker/colorpicker_hex.png) top;left:212px;top:142px}.colorpicker_hex input{right:6px}.colorpicker_field{height:22px;width:62px;background-position:top;position:absolute}.colorpicker_field span{position:absolute;width:12px;height:22px;overflow:hidden;top:0;right:0;cursor:n-resize}.colorpicker_rgb_r{background-image:url(../images/colorPicker/colorpicker_rgb_r.png);top:52px;left:212px}.colorpicker_rgb_g{background-image:url(../images/colorPicker/colorpicker_rgb_g.png);top:82px;left:212px}.colorpicker_rgb_b{background-image:url(../images/colorPicker/colorpicker_rgb_b.png);top:112px;left:212px}.colorpicker_hsb_h{background-image:url(../images/colorPicker/colorpicker_hsb_h.png);top:52px;left:282px}.colorpicker_hsb_s{background-image:url(../images/colorPicker/colorpicker_hsb_s.png);top:82px;left:282px}.colorpicker_hsb_b{background-image:url(../images/colorPicker/colorpicker_hsb_b.png);top:112px;left:282px}.colorpicker_submit{position:absolute;width:22px;height:22px;background:url(../images/colorPicker/colorpicker_submit.png) top;left:322px;top:142px;overflow:hidden}.colorpicker_focus{background-position:center}.colorpicker_hex.colorpicker_focus{background-position:bottom}.colorpicker_submit.colorpicker_focus{background-position:bottom}.colorpicker_slider{background-position:bottom}#colorSelector{position:relative;width:36px;height:36px;background:url(../images/colorPicker/select.png)}#colorSelector div{position:absolute;top:3px;left:3px;width:30px;height:30px;background:url(../images/colorPicker/select.png) center}#colorSelector2{position:absolute;top:0;left:0;width:36px;height:36px;background:url(../images/colorPicker/select2.png)}#colorSelector2 div{position:absolute;top:4px;left:4px;width:28px;height:28px;background:url(../images/colorPicker/select2.png) center}#colorpickerHolder2{top:32px;left:0;width:356px;height:0;overflow:hidden;position:absolute}#colorpickerHolder2 .colorpicker{background-image:url(../images/colorPicker/custom_background.png);position:absolute;bottom:0;left:0}#colorpickerHolder2 .colorpicker_hue div{background-image:url(../images/colorPicker/custom_indic.gif)}#colorpickerHolder2 .colorpicker_hex{background-image:url(../images/colorPicker/custom_hex.png)}#colorpickerHolder2 .colorpicker_rgb_r{background-image:url(../images/colorPicker/custom_rgb_r.png)}#colorpickerHolder2 .colorpicker_rgb_g{background-image:url(../images/colorPicker/custom_rgb_g.png)}#colorpickerHolder2 .colorpicker_rgb_b{background-image:url(../images/colorPicker/custom_rgb_b.png)}#colorpickerHolder2 .colorpicker_hsb_s{background-image:url(../images/colorPicker/custom_hsb_s.png);display:none}#colorpickerHolder2 .colorpicker_hsb_h{background-image:url(../images/colorPicker/custom_hsb_h.png);display:none}#colorpickerHolder2 .colorpicker_hsb_b{background-image:url(../images/colorPicker/custom_hsb_b.png);display:none}#colorpickerHolder2 .colorpicker_submit{background-image:url(../images/colorPicker/custom_submit.png)}#colorpickerHolder2 .colorpicker input{color:#778398}#customWidget{position:relative;height:36px}#popup_container{min-width:300px;max-width:600px;background:url(../images/alertOpacityOverlay.png) repeat;-moz-border-radius:5px;-webkit-border-radius:5px;border-radius:5px;max-height:70%;top:0;overflow:scroll}#popup_title{text-align:center;background:url(../images/leftNavBg.png) repeat-x;border-bottom:1px solid #d5d5d5;cursor:default;padding:9px 0 9px 0;margin:0;height:20px}#popup_content{background:#fafafa;padding:1em 1.75em;margin:0}#popup_message{text-align:center}#popup_panel{text-align:center;margin:1em 0 0 0}#popup_message input[type=text]{background:#fcfcfc;border:1px solid #d1d1d1;padding:5px;width:258px}#popup_prompt{margin:.5em 0}#suspend_popup{min-width:300px;max-width:600px;background:url(../images/alertOpacityOverlay.png) repeat;-moz-border-radius:5px;-webkit-border-radius:5px;border-radius:5px;max-height:101%;top:0}#suspend_popup_title{text-align:center;background:url(../images/leftNavBg.png) repeat-x;border-bottom:1px solid #d5d5d5;cursor:default;padding:9px 0 9px 0;margin:0;height:20px}#suspend_popup_content{background:#fafafa;padding:1em 1.75em;margin:0}#suspend_popup_message{text-align:center}#suspend_popup_message .item{text-align:left}#suspend_popup_message .item input{width:auto}#suspend_popup_panel{text-align:center;margin:1em 0 0 0}#suspend_popup_prompt{margin:.5em 0}#suspend_popup_panel #popup_cancel,#suspend_popup_panel #popup_ok{width:auto}#help_popup{min-width:300px;max-width:600px;background:url(../images/alertOpacityOverlay.png) repeat;-moz-border-radius:5px;-webkit-border-radius:5px;border-radius:5px;max-height:101%;top:0}#help_popup_title{text-align:center;background:url(../images/leftNavBg.png) repeat-x;border-bottom:1px solid #d5d5d5;cursor:default;padding:9px 0 9px 0;margin:0;height:20px}#help_popup_content{background:#fafafa;padding:1em 1.75em;margin:0}#help_popup_message{text-align:center}#help_popup_message .item{text-align:left}#help_popup_message .item input{width:auto}#help_popup_panel{text-align:center;margin:1em 0 0 0}#help_popup_prompt{margin:.5em 0}#help_popup_panel #popup_cancel,#help_popup_panel #popup_ok{width:auto}.errorPage{width:370px;margin:100px auto 80px auto;position:relative}.errorPage .errorTitle,.weAreOff{background:url(../images/linesSep.png) repeat-x 0 100%;width:290px;padding-bottom:15px}.weAreOff{width:100%}.errorPage h1{color:#404040;font-size:140px;margin:80px 0;position:relative;padding-left:10px}.errorPage h2{font-size:22px;font-weight:400}.errorPage h2 span{background:url(../images/sadEmo.png) no-repeat 0;padding-left:26px}.errorPage .bubbles{position:absolute;background:url(../images/error.png) no-repeat 0 0;width:138px;height:133px;top:-10px;left:225px}.errorPage p{width:100%;padding:13px 0;background:url(../images/linesSep.png) repeat-x 0 0;font-size:20px;text-align:center}.backToDash{text-align:center;margin:10px}.plupload_button{font-size:10px;font-weight:700;text-transform:uppercase;color:#fff;line-height:12px;margin-top:3px}.plupload_start{float:left;background:url(../images/ui/greenBtn.png) repeat-x 0 0;border:1px solid #418d4f}.plupload_start span{background:url(../images/upload.png) no-repeat 10px;padding:5px 13px 6px 26px;display:block}.plupload_start:hover{background-position:0 -25px}.plupload_start:active{background-position:0 -50px}.plupload_disabled,a.plupload_disabled:hover{color:#a6a6a6;border:1px solid #e9e9e9;background:url(../images/ui/uploadDisabled.png) repeat-x;cursor:default}.plupload_disabled span{padding:5px 13px 6px 13px}.plupload_add{margin-right:10px;background:url(../images/ui/greyishBtn.png) repeat-x 0 0;border:1px solid #4f5a68;float:left}.plupload_add span{background:url(../images/add.png) no-repeat 10px;padding:5px 13px 6px 26px;display:block}.plupload_add:hover{background-position:0 -25px}.plupload_add:active{background-position:0 -50px}.plupload_wrapper{font-size:11px;width:100%}.plupload_container input{border:1px solid #ddd;font-size:11px;width:98%}.plupload_filelist{margin:0;padding:0;list-style:none}.plupload_scroll .plupload_filelist{height:185px;background:#fafafa;overflow-y:scroll}.plupload_filelist li{padding:10px 12px;background:#f5f5f5;border-bottom:1px solid #e7e7e7}.plupload_filelist li:hover{background:#fdfdfd}.plupload_filelist_footer,.plupload_filelist_header{background:#efefef url(../images/leftNavBg.png) repeat-x;padding:3px 12px;color:#878787}.plupload_filelist_header{border-bottom:1px solid #d5d5d5}.plupload_filelist_footer{border-top:1px solid #d5d5d5;height:31px;line-height:30px;vertical-align:middle}.plupload_file_name{float:left;overflow:hidden}.plupload_file_status{color:#777}.plupload_file_size,.plupload_file_status,.plupload_progress{float:right;width:80px}.plupload_file_action,.plupload_file_size,.plupload_file_status{text-align:right}.plupload_filelist .plupload_file_name{width:205px}.plupload_file_action{float:right;width:14px;margin-top:3px;height:14px;margin-left:15px}.plupload_file_action *{display:none;width:14px;height:14px}li.plupload_done{color:#aaa}li.plupload_delete a{background:url(../images/uploader/deleteFile.png) no-repeat 0}li.plupload_failed a{background:url(../images/uploader/error.png) no-repeat 0;cursor:default}li.plupload_done a{background:url(../images/uploader/uploaded.png) no-repeat 0;cursor:default}.plupload_progress,.plupload_upload_status{display:none}.plupload_progress_container{margin-top:10px;border:1px solid #ccc;background:#fff;padding:1px}.plupload_progress_bar{width:0;height:7px;background:#cdeb8b}.plupload_scroll .plupload_filelist_footer .plupload_file_action,.plupload_scroll .plupload_filelist_header .plupload_file_action{margin-right:17px}.plupload_clear,.plupload_clearer{clear:both}.plupload_clearer,.plupload_progress_bar{display:block;font-size:0;line-height:0}li.plupload_droptext{background:0 0;text-align:center;vertical-align:middle;border:0;line-height:165px}.swMain{position:relative}.swMain .stepContainer{display:block;position:relative;overflow:hidden;clear:both}.swMain .stepContainer div.wContent{display:block;position:absolute;float:left;margin:0;text-align:left;overflow:visible;z-index:88;clear:both;width:100%}.swMain .stepContainer div.wContent p{padding:12px}.swMain div.actionBar{display:block;position:relative;clear:both;padding:0;color:#5a5655;height:41px;text-align:left;overflow:auto;z-index:88;left:0;background:#efefef url(../images/leftNavBg.png) repeat-x;border-top:1px solid #d5d5d5}.actionBar a.button{box-shadow:none}.swMain .stepContainer .StepTitle{display:block;position:relative;margin:0;border:1px solid #e0e0e0;padding:5px;color:#5a5655;clear:both;text-align:left;z-index:88}.swMain ul.anchor{position:relative;display:block;float:left;list-style:none;padding:0;clear:both;border-top:1px solid #d5d5d5;border-bottom:1px solid #d5d5d5;width:100%}.swMain ul.anchor li{position:relative;display:block;margin:0;padding:0;float:left;width:25%}.swMain ul.anchor li:first-child{border-left:none}.swMain ul.anchor li a{display:block;position:relative;float:left;margin:0;height:38px;width:100%;text-decoration:none;outline-style:none;z-index:99;cursor:pointer;background:url(../images/leftNavBg.png) repeat-x;border-left:1px solid #d5d5d5}.swMain ul.anchor li:first-child a{border-left:none}.swMain ul.anchor li a .stepNumber{position:relative;float:left;width:30px;text-align:center;padding:5px;padding-top:0}.swMain ul.anchor li a .stepDesc{position:relative;display:block;float:left;text-align:left;padding:8px 12px 8px 35px;white-space:nowrap}.swMain ul.anchor li a.selected{color:#3581c1;background:#fafafa}.swMain ul.anchor li a.done{position:relative;color:#aaa;z-index:99;background:#efefef}.swMain ul.anchor li a.done:hover{color:#5a5655}.swMain ul.anchor li a.disabled{color:#424242;cursor:text}.swMain ul.anchor li a.error{color:#6c6c6c!important;border:1px solid #fb3500!important}.swMain ul.anchor li a.error:hover{color:#000!important}.swMain .buttonNext{display:block;float:right;margin:8px 12px 0 12px;padding:6px 12px}.swMain .buttonDisabled{color:#d5d5d5!important;cursor:text;background:#f1f1f1!important;margin-top:8px!important;border:1px solid #e1e1e1}.swMain .buttonPrevious{display:block;float:right;margin:8px 0 0 0;padding:6px 12px}.swMain .buttonFinish{display:block;float:right;margin:8px 12px 0 0;padding:6px 12px}.swMain .loader{position:relative;display:none;float:left;margin:2px 0 0 2px;padding:8px 10px 8px 40px;border:1px solid gold;color:#5a5655;background:url(../images/loaders/loader.gif) no-repeat 5px;z-index:998}.swMain .msgBox{position:relative;display:none;float:left;margin:4px 0 0 5px;padding:5px;border:1px solid gold;background-color:#ffd;color:#5a5655;z-index:999;min-width:200px}.swMain .msgBox .content{padding:0;float:left}.swMain .msgBox .close{border:1px solid #d5d5d5;color:#ccc;display:block;float:right;margin:0 0 0 5px;outline-style:none;padding:0 2px 0 2px;position:relative;text-align:center;text-decoration:none}.swMain .msgBox .close:hover{color:#ea8511;border:1px solid #d5d5d5}.bordLeft{border-top-left-radius:3px;-moz-border-radius-topleft:3px;-webkit-border-top-left-radius:3px}.bordRight{border-top-right-radius:3px;-moz-border-radius-topright:3px;-webkit-border-top-right-radius:3px}.contentHead{padding:16px 12px 15px 35px}.timepicker{width:60px!important}.timeEntry_control{vertical-align:middle;margin-left:-1px;margin-top:-2px;cursor:pointer}* html .timeEntry_control{margin-top:-4px}.dualBoxes{padding:22px 16px;position:relative}.dualBtn{padding:6px 8px;cursor:pointer;line-height:12px;background:url(../images/ui/basicBtn.png) repeat-x 0 0;border:1px solid #d5d5d5;color:#525252;margin-left:-1px}.dualBtn:hover{background-position:0 -25px;border-color:#c9c9c9}.dualBtn:active{background-position:0 -50px}.fltr{position:absolute;right:0}.boxFilter{margin-bottom:15px}.dualControl{text-align:center;width:90px;margin:150px 1px;position:absolute;left:50%;margin-left:-45px}.countLabel{color:gray;font-style:italic;margin-top:10px;display:block}.storageBox{display:none}.copiedOption{background-color:#ff0}.feat{margin-left:5px;background:url(../images/forms/fileUpload.png) no-repeat 0 0;width:94px;height:26px}.feat:hover{background-position:0 -27px}.feat:active{background-position:0 -54px}.fileInput{background:#fff;border:1px solid #d5d5d5;padding:5px;font-size:11px;font-family:Arial,Helvetica,sans-serif}.fileInput:hover{background:#fcfcfc;border:1px solid #d1d1d1}.fileInput:focus{border:1px solid #bbc1c9;background:#fff}.step{position:relative}.step label.error{color:#b84646;padding-left:0;font-size:11px;white-space:nowrap;padding-bottom:0}.selector .error{position:absolute;right:-114px}.step h5{position:absolute;left:12px;top:-30px}.wizNav{padding:14px 16px;border-top:1px solid #e7e7e7;text-align:right}.wizNav input{margin-left:10px}.wizNav input[disabled]{background:#fcfcfc;border:1px solid #eaeaea;color:#d5d5d5}.chzn-container{position:relative;display:inline-block;zoom:1}.noSearch .chzn-search,.noSearch .selector,.searchDrop .selector{display:none}.formRight .chzn-container-multi{width:100%!important}.noSearch .chzn-results{margin:0!important;padding:2px!important}.chzn-container>.chzn-drop{background:#fff;border:1px solid #d5d5d5;border-top:0;position:absolute;top:29px;margin-top:1px;left:0;z-index:998;width:100%!important;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;-ms-box-sizing:border-box;box-sizing:border-box}.chzn-container-single .chzn-single{background:url(../images/chosenSelect.png) repeat-x;border:1px solid #d8d8d8;display:block;overflow:hidden;white-space:nowrap;position:relative;height:26px;line-height:27px;padding:0 0 0 8px;color:#595959;text-decoration:none}.chzn-container-single .chzn-single span{margin-right:26px;display:block;font-size:11px;overflow:hidden;white-space:nowrap;-o-text-overflow:ellipsis;-ms-text-overflow:ellipsis;text-overflow:ellipsis}.chzn-container-single .chzn-single abbr{display:block;position:absolute;right:26px;top:6px;width:12px;height:13px;font-size:1px}.chzn-container-single .chzn-single div{position:absolute;right:-1px;top:-1px;display:block;height:28px;width:27px}.chzn-container-single .chzn-single div b{background:url(../images/forms/select_right.png) no-repeat center right;display:block;width:27px;height:28px}.chzn-container-single .chzn-search{padding:3px 4px;position:relative;margin:0;white-space:nowrap;z-index:1010}.chzn-container-single .chzn-search input{margin:1px 0;padding:4px 20px 4px 5px;outline:0;border:1px solid #aaa;font-family:sans-serif;font-size:11px;background:url(../images/searchSmall.png) no-repeat 98%!important;box-sizing:content-box;-webkit-box-sizing:content-box;-moz-box-sizing:content-box;-ms-box-sizing:content-box}.chzn-container-single-nosearch .chzn-search input{position:absolute;left:-9000px}.chzn-container-multi .chzn-choices{border:1px solid #ddd;margin:0;cursor:text;overflow:hidden;height:auto!important;height:1%;position:relative;font-size:12px;padding:4px;background:#fff;color:#656565}.chzn-container-multi .chzn-choices li{float:left;list-style:none}.chzn-container-multi .chzn-choices .search-field{white-space:nowrap;margin:0;padding:0}.chzn-container-multi .chzn-choices .search-field input{color:#666;background:0 0!important;border:0!important;font-family:sans-serif;font-size:12px!important;padding:11px 4px 10px 4px!important;margin:0;outline:0;box-shadow:none!important}.chzn-container-multi .chzn-choices .search-field .default{color:#999}.chzn-container-multi .chzn-choices .search-choice{position:relative;line-height:16px;font-size:11px;border:1px solid #a5d24a;display:block;float:left;padding:5px 24px 5px 8px;background:#cde69c;color:#638421;margin:4px}.chzn-container-multi .chzn-choices .search-choice-focus{background:#d4d4d4}.chzn-container-multi .chzn-choices .search-choice .search-choice-close{display:block;position:absolute;right:6px;top:8px;width:10px;height:10px;font-size:1px;background:url(../images/icons/closeSelection.png) 50% no-repeat}.chzn-container-multi .chzn-choices .search-choice-focus .search-choice-close{background-position:right -11px}.chzn-container .chzn-results{margin:0 4px 4px 0;max-height:240px;padding:0 0 0 4px;position:relative;overflow-x:hidden;overflow-y:auto}.chzn-container-multi .chzn-results{padding:0;margin:0}.chzn-container .chzn-results li{display:none;line-height:14px;padding:5px 6px;margin:0;list-style:none;font-size:11px}.chzn-container .chzn-results .active-result{cursor:pointer;display:list-item}.chzn-container .chzn-results .highlighted{background-color:#3875d7;color:#fff}.chzn-container .chzn-results li em{background:#feffde;font-style:normal}.chzn-container .chzn-results .highlighted em{background:0 0}.chzn-container .chzn-results .no-results{background:#f4f4f4;display:list-item}.chzn-container .chzn-results .group-result{cursor:default;color:#2e74a6;font-weight:700;font-size:10px;border-bottom:1px solid #ddd;border-top:1px solid #ddd}.chzn-container .chzn-results .group-option{padding-left:15px}.chzn-container-multi .chzn-drop .result-selected{display:none}.chzn-container .chzn-results-scroll{background:#fff;margin:0 4px;position:absolute;text-align:center;width:321px;z-index:1}.chzn-container .chzn-results-scroll span{display:inline-block;height:17px;text-indent:-5000px;width:9px}.chzn-container .chzn-results-scroll-down{bottom:0}.chzn-container-active .chzn-single-with-drop div{background:0 0;border-left:none}.chzn-container-active .chzn-choices{border:1px solid #d5d5d5}.chzn-container-active .chzn-choices .search-field input{color:#111!important}.chzn-disabled{cursor:default;opacity:.5!important}.chzn-disabled .chzn-single{cursor:default}.chzn-disabled .chzn-choices .search-choice .search-choice-close{cursor:default}@media only screen and (max-width:799px){.leftNav{float:none;background:url(../images/linesSep.png) repeat-x;padding-top:24px;text-align:center;padding-bottom:20px;margin:0;width:100%;max-width:none}.leftNav ul li{width:49px;display:inline-block;margin:0 0 4px 0;position:static}.leftNav ul li a span{text-indent:-9999px;background-position:16px}.leftNav ul li a{margin-bottom:3px}.numberLeft{display:none!important}.widgets .left{float:none;width:100%;margin-right:0}.widgets .right{float:none;width:100%}#header{text-align:center;height:100%;margin-bottom:22px}ul.sub{position:absolute;width:100%;left:0;z-index:999;border:1px solid #d5d5d5;border-bottom:0}ul.sub li{display:block;width:50%;float:left;margin-bottom:0;text-align:left;border-bottom:1px solid #d5d5d5;padding:0}ul.sub li a{padding:8px 10px 8px 24px;background:url(../images/arrow.gif) no-repeat 12px 16px}.sub li a:active,ul.sub li a:hover{background-position:12px 16px}ul.sub li:nth-child(odd){background:url(../images/tabsSepR.png) repeat-y 100% 0}ul#menu{position:relative}.leftNav .last{border-bottom:1px solid #d5d5d5}}@media only screen and (max-width:767px){.stats ul li{display:inline-block;float:none;margin-left:18px;vertical-align:top;width:21%;text-align:center}.stats ul{text-align:center}.count{display:inline-block;float:none;padding:0 15px;text-align:center;margin-bottom:4px;margin-right:0}.middleNav{float:none;margin-right:0;display:block;text-align:center;margin-top:2px}.middleNav ul li{text-align:center;display:inline-block;float:none;margin-left:5%;position:relative}.middleNav ul li:first-child{margin-left:0}.logo{float:none}.userNav ul li span{display:none}.userNav ul li img{padding:13px 14px 11px 14px;margin:0}.userNav ul li ul{right:-3px;left:auto}.listData .cNote{display:none}ul.listData li{padding:0 0 1px 6px!important}.rowElem>label{width:100%;float:none;padding:8px 0 6px 0}.formRight{width:100%;margin:0;padding:12px 0;float:none}.rowElem .topLabel{padding:5px 12px 5px 0}.fc-header-right{width:50%}.ln-letters a{padding:4px 2%;margin-bottom:1px}#eq span{margin-right:0;margin-left:30px}#eq span:first-child{margin-left:5px}.formError{left:auto!important;right:30px}.formErrorContent{width:140px}.formRight div.checker,.formRight div.radio{padding-bottom:0;padding-top:0;margin-top:2px}div.selector{margin-bottom:10px}.formRight>label{padding-top:0}.rowElem>label{padding-bottom:0}.step label.error{padding-top:3px}.userWidget .checker{margin-top:6px}}@media only screen and (min-width:800px) and (max-width:979px){.leftNav{width:24%}}@media only screen and (min-width:320px) and (max-width:479px){.logo{float:none;text-align:center}.welcome{display:none}.userNav{float:none;text-align:center;position:relative}.userNav ul{height:36px;text-align:center}.userNav>ul>li{display:inline-block;float:none;position:static;margin-left:-3px}.userNav ul li ul{height:auto;text-align:left;position:absolute;top:36px;left:50%;margin-left:-85px;width:162px}.middleNav ul{text-align:center}.middleNav ul li{text-align:center;display:inline-block;float:none;margin:0 2%;position:relative;width:45%;margin-bottom:10px}.middleNav ul li:first-child{margin:0 2%}.stats ul{text-align:center}.stats ul li{display:inline-block;float:none;margin:5px;vertical-align:top;width:46%;text-align:center}.stats ul li:first-child{margin:5px}.count{display:inline-block;float:none;padding:0 15px;text-align:center;margin-bottom:4px;margin-right:0;width:75%}.w40{width:auto}.floatleft,.floatright{float:none}.floatright{margin-top:95px}.countLabel{text-align:center}.dualControl{text-align:center;width:90px;margin:10px 1px;position:absolute;left:50%;margin-left:-45px}.moreFields ul li{width:11.8%}.moreFields ul li span{display:none}#header{margin-bottom:15px}.checker,.radio{clear:both}.plupload_file_size,.plupload_file_status,.plupload_progress{width:12%}.plupload_disabled span{padding:5px 8px 6px 8px}.plupload_add span{background:url(../images/add.png) no-repeat 10px;padding:5px 8px 6px 20px;display:block}.fc-header-right{width:auto}.dataTables_filter input[type=text]{width:86px}.dataTables_paginate{float:left}.dataTables_paginate .ui-buttonset .ui-button{margin:0 1px}.issueSummary .floatleft{display:none}.ticketInfo{margin-left:0}.breadCrumb{overflow:hidden;height:100%}.pages li{display:inline-block;margin:4px 2px}#popup_container{min-width:250px;max-width:300px}.el-finder-nav{width:100px}.errorPage{width:auto}.errorPage .bubbles{display:none}.errorPage .errorTitle,.weAreOff{width:auto}.errorPage h1{padding:0;text-align:center}#myList>li{clear:both}ul.listData{float:left;text-align:center;margin:3px 0 5px 0;font-size:11px}ul.listData li{padding:0;margin:0 20px 0 -6px;clear:both}.displayNone{display:none}.pieWidget{width:100%;height:250px;margin:0 auto}.paging_full_numbers .ui-button{padding:2px 5px}table.display{table-layout:fixed}table.display thead th div.DataTables_sort_wrapper{overflow:hidden;padding-right:10px}table.display thead th div.DataTables_sort_wrapper span{display:none}table.display td{overflow:hidden}.dataTables_length{float:none;margin:6px auto 0 auto;width:140px}.dataTables_paginate{float:none;width:253px;display:inline-block;text-align:center;margin-top:2px}.chzn-container{width:254px!important}.chzn-container-single .chzn-search input{max-width:218px}}@media only screen and (min-width:480px) and (max-width:767px){.moreFields ul li{width:13.4%}.moreFields ul li span{display:none}}.moreFields div.radio span{padding:0}.truncate{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.dark-sprite-icon{margin:auto 0;display:inline-block;background-repeat:no-repeat}.sprite-topnav{background-repeat:no-repeat;display:inline-block}.sprite-23{background-repeat:no-repeat;display:block;margin:0 auto}.ajax-loader{background:url(../images/loader.gif);width:16px;height:11px;display:inline-block}
+.sprite-abacus {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-add {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-addressBook {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-adminUser {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-adminUser2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-airplane {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-alarm {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-alert {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-alert2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-android {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-archive {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-arrowDown {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-arrowLeft {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-arrowRight {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-arrowUp {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-bag {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-baloons {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-bandaid {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-basket {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-basket2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-battery {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-batteryFull {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-bell {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-bell2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-bigBrush {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-blackberry {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-block {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-blocks {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-bluetooth {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-bluetooth2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-bluray {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-book {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-bookLarge {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-books {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-bright {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-bubbles {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-bubbles2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-building {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-bullsEye {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-buzz {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-calc {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-camera {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-camera2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-car {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cart {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cart2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cart3 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cart4 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cashRegister {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cassette {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-cat {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cd {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-chair {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-chart {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-chart2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-chart3 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-chart4 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-chart5 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-chart6 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-chart7 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-chart8 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-check {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-chemical {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-chrome {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-clipboard {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-clock {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-close {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cloud {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cloudDownload {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cloudUpload {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cog {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cog2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cog3 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cog4 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-companies {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-computer {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-coverflow {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-create {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cup {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-cut {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-dayCalendar {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-delicious {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-denied {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-dialog {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-digg {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-digg2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-doc {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-docs {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-download {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-download2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-download3 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-dribbble {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-dribbble2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-drive {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-dropbox {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-dropper {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-drupal {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-dvd {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-electricity {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-electroPlug {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-excelDoc {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-exit {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-expengine {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-expose {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-facebook {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-fax {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-femaleContour {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-femaleSymbol {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-files {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-filmCamera {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-filmStrip {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-filmStrip2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-firefox {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-flag {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-flag2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-flagFinished {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-folder {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-footprints {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-fountainPen {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-frames {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-full {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-full2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-fullscreen {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-globe {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-globe2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-gmaps {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-goBack {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-goFull {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-graph {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-hd {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-hd2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-hd3 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-headphones {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-heart {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-help {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-home {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-home2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-icecream {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-ichat {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-image {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-image2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-imageList {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-images {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-images2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-imagesList {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-inbox {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-inbox2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-incoming {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-info {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-ipad {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-iphone {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-ipodClassic {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-ipodNano {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-joomla {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-key {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-ladyPurse {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-lamp {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-laptop {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-lastFM {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-lemonadeStand {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-lightBulb {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-like {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-link {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-link2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-linux {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-list {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-loading {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-locked {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-locked2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-logoff {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-macos {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-magicMouse {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-magnify {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-mail {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-maleContour {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-maleSymbol {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-map {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-medicalCase {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-megaphone {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-microphone {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-mightyMouse {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-mobile {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-mobyPicture {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-money {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-money2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-monitor {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-monthCalendar {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-mouse {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-music {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-myspace {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-notebook {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-outgoing {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-pacman {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-paintBrush {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-pants {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-paperclip {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-paypal {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-paypal2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-paypal3 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-pdfDoc {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-pencil {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-phone {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-phone2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-phone3 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-photos {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-piggyBank {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-pin {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-planeSuitcase {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-play {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-play2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-plixi {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-podium {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-postcard {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-power {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-powerBattery {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-ppDoc {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-presentation {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-preview {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-priceTag {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-priceTags {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-printer {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-radio {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-record {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-recycle {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-refresh {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-refresh2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-refresh3 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-refresh4 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-repeat {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-robot {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-rss {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-ruler {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-ruler2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-runningMan {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-safari {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-scanLabel {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-sd {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-sd2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-sd3 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-settings {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-settings2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-shirt {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-shoppingBag {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-shuffle {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-signPost {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-signal {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-skype {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-smallBrush {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-socks {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-sound {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-speech {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-speech2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-star {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-stats {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-stop {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-stopWatch {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-strategy {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-strategy2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-stumble {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-suitcase {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-switcher {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-table {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-tag {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-tags {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-timer {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-transfer {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-trash {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -140px;
+	width: 14px;
+	height: 14px
+}
+.sprite-travelSuitcase {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -154px;
+	width: 14px;
+	height: 14px
+}
+.sprite-tree {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -168px;
+	width: 14px;
+	height: 14px
+}
+.sprite-trolly {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -182px;
+	width: 14px;
+	height: 14px
+}
+.sprite-truck {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -196px;
+	width: 14px;
+	height: 14px
+}
+.sprite-tumbler {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -210px;
+	width: 14px;
+	height: 14px
+}
+.sprite-tv {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: 0 -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-twitter {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -14px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-twitter2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -28px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-umbrella {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -42px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-underConstruction {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -56px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-unlocked {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -70px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-upload {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -84px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-user {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -98px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-user2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -112px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-userComment {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -126px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-users {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -140px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-users2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -154px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-vault {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -168px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-vcard {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -182px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-view {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -196px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-vimeo {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -210px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-vimeo2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -224px -224px;
+	width: 14px;
+	height: 14px
+}
+.sprite-walkingMan {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -238px 0;
+	width: 14px;
+	height: 14px
+}
+.sprite-wifi {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -238px -14px;
+	width: 14px;
+	height: 14px
+}
+.sprite-wifi2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -238px -28px;
+	width: 14px;
+	height: 14px
+}
+.sprite-windows {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -238px -42px;
+	width: 14px;
+	height: 14px
+}
+.sprite-wordDoc {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -238px -56px;
+	width: 14px;
+	height: 14px
+}
+.sprite-wordpress {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -238px -70px;
+	width: 14px;
+	height: 14px
+}
+.sprite-wordpress2 {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -238px -84px;
+	width: 14px;
+	height: 14px
+}
+.sprite-youtube {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -238px -98px;
+	width: 14px;
+	height: 14px
+}
+.sprite-zip {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -238px -112px;
+	width: 14px;
+	height: 14px
+}
+.sprite-zipFiles {
+	background-image: url(../sprites/dark-icons-sprite.png);
+	background-position: -238px -126px;
+	width: 14px;
+	height: 14px
+}
+.sprite-23-basket2 {
+	background-image: url(../sprites/dark-icons-23-sprite.png);
+	background-position: 0 0;
+	width: 23px;
+	height: 23px
+}
+.sprite-23-dialog {
+	background-image: url(../sprites/dark-icons-23-sprite.png);
+	background-position: -23px 0;
+	width: 23px;
+	height: 23px
+}
+.sprite-23-home {
+	background-image: url(../sprites/dark-icons-23-sprite.png);
+	background-position: 0 -23px;
+	width: 23px;
+	height: 23px
+}
+.sprite-23-money {
+	background-image: url(../sprites/dark-icons-23-sprite.png);
+	background-position: -23px -23px;
+	width: 23px;
+	height: 23px
+}
+.sprite-23-speech {
+	background-image: url(../sprites/dark-icons-23-sprite.png);
+	background-position: -46px 0;
+	width: 23px;
+	height: 23px
+}
+.sprite-23-user {
+	background-image: url(../sprites/dark-icons-23-sprite.png);
+	background-position: -46px -23px;
+	width: 23px;
+	height: 23px
+}
+.sprite-topnav-contactAdmin {
+	background-image: url(../sprites/topnav-sprite.png);
+	background-position: -22px 0;
+	width: 11px;
+	height: 10px
+}
+.sprite-topnav-help {
+	background-image: url(../sprites/topnav-sprite.png);
+	background-position: 0 -22px;
+	width: 10px;
+	height: 10px
+}
+.sprite-topnav-logout {
+	background-image: url(../sprites/topnav-sprite.png);
+	background-position: 0 0;
+	width: 11px;
+	height: 11px
+}
+.sprite-topnav-mainWebsite {
+	background-image: url(../sprites/topnav-sprite.png);
+	background-position: -10px -22px;
+	width: 10px;
+	height: 10px
+}
+.sprite-topnav-messages {
+	background-image: url(../sprites/topnav-sprite.png);
+	background-position: -11px 0;
+	width: 11px;
+	height: 11px
+}
+.sprite-topnav-profile {
+	background-image: url(../sprites/topnav-sprite.png);
+	background-position: 0 -11px;
+	width: 11px;
+	height: 11px
+}
+.sprite-topnav-register {
+	background-image: url(../sprites/topnav-sprite.png);
+	background-position: -20px -22px;
+	width: 10px;
+	height: 10px
+}
+.sprite-topnav-settings {
+	background-image: url(../sprites/topnav-sprite.png);
+	background-position: -22px -10px;
+	width: 10px;
+	height: 11px
+}
+.sprite-topnav-tasks {
+	background-image: url(../sprites/topnav-sprite.png);
+	background-position: -11px -11px;
+	width: 11px;
+	height: 11px
+}
+.ui-helper-hidden {
+	display: none
+}
+.ui-helper-hidden-accessible {
+	position: absolute;
+	left: -99999999px
+}
+.ui-helper-reset {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	outline: 0;
+	line-height: 1.3;
+	text-decoration: none;
+	font-size: 100%;
+	list-style: none
+}
+.ui-helper-clearfix:after {
+	content: ".";
+	display: block;
+	height: 0;
+	clear: both;
+	visibility: hidden
+}
+.ui-helper-clearfix {
+	display: inline-block
+}
+* html .ui-helper-clearfix {
+	height: 1%
+}
+.ui-helper-clearfix {
+	display: block
+}
+.ui-helper-zfix {
+	width: 100%;
+	height: 100%;
+	top: 0;
+	left: 0;
+	position: absolute;
+	opacity: 0;
+	filter: Alpha(Opacity=0)
+}
+.ui-state-disabled {
+	cursor: default!important
+}
+.ui-icon {
+	display: block;
+	text-indent: -99999px;
+	overflow: hidden;
+	background-repeat: no-repeat
+}
+.ui-widget-overlay {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%
+}
+.ui-widget {
+	font-size: 12px
+}
+.ui-widget .ui-widget {
+	font-size: 1em
+}
+.ui-widget button,
+.ui-widget input,
+.ui-widget select,
+.ui-widget textarea {
+	font-family: Verdana, Arial, sans-serif;
+	font-size: 1em
+}
+.ui-widget-content a {
+	color: #222
+}
+.ui-widget-header {
+	font-weight: 700
+}
+.ui-widget-header a {
+	color: #222
+}
+.ui-state-default,
+.ui-widget-content .ui-state-default,
+.ui-widget-header .ui-state-default {
+	border-left: 1px solid #d5d5d5;
+	font-weight: 400;
+	border-bottom: 1px solid #d5d5d5
+}
+th.ui-state-default:first-child {
+	border-left: none
+}
+.ui-state-default a,
+.ui-state-default a:link,
+.ui-state-default a:visited {
+	color: #555;
+	text-decoration: none
+}
+.ui-state-focus,
+.ui-state-hover,
+.ui-widget-content .ui-state-focus,
+.ui-widget-content .ui-state-hover,
+.ui-widget-header .ui-state-focus,
+.ui-widget-header .ui-state-hover {
+	background: #fafafa;
+	font-weight: 400;
+	color: #212121
+}
+.ui-state-hover a,
+.ui-state-hover a:hover {
+	color: #797979;
+	text-decoration: none
+}
+.ui-state-active,
+.ui-widget-content .ui-state-active,
+.ui-widget-header .ui-state-active {
+	background: #fafafa;
+	font-weight: 400;
+	color: #797979
+}
+.ui-state-active a,
+.ui-state-active a:link,
+.ui-state-active a:visited {
+	color: #797979;
+	text-decoration: none
+}
+.ui-widget:active {
+	outline: 0
+}
+.ui-state-highlight a,
+.ui-widget-content .ui-state-highlight a,
+.ui-widget-header .ui-state-highlight a {
+	color: #363636
+}
+.ui-state-error,
+.ui-widget-content .ui-state-error,
+.ui-widget-header .ui-state-error {
+	border: 1px solid #cd0a0a;
+	background: #fef1ec url(../images/jquery_ui/ui-bg_glass_95_fef1ec_1x400.png) 50% 50% repeat-x;
+	color: #cd0a0a
+}
+.ui-state-error a,
+.ui-widget-content .ui-state-error a,
+.ui-widget-header .ui-state-error a {
+	color: #cd0a0a
+}
+.ui-state-error-text,
+.ui-widget-content .ui-state-error-text,
+.ui-widget-header .ui-state-error-text {
+	color: #cd0a0a
+}
+.ui-priority-primary,
+.ui-widget-content .ui-priority-primary,
+.ui-widget-header .ui-priority-primary {
+	font-weight: 700
+}
+.ui-priority-secondary,
+.ui-widget-content .ui-priority-secondary,
+.ui-widget-header .ui-priority-secondary {
+	opacity: .7;
+	filter: Alpha(Opacity=70);
+	font-weight: 400
+}
+.ui-state-disabled,
+.ui-widget-content .ui-state-disabled,
+.ui-widget-header .ui-state-disabled {
+	opacity: .35;
+	filter: Alpha(Opacity=35);
+	background-image: none
+}
+.ui-icon {
+	width: 16px;
+	height: 16px;
+	background-image: url(../images/jquery_ui/ui-icons_222222_256x240.png)
+}
+.ui-widget-content .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_222222_256x240.png)
+}
+.ui-widget-header .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_222222_256x240.png)
+}
+.ui-state-default .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_888888_256x240.png)
+}
+.ui-state-focus .ui-icon,
+.ui-state-hover .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_454545_256x240.png)
+}
+.ui-state-active .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_454545_256x240.png)
+}
+.ui-state-highlight .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_2e83ff_256x240.png)
+}
+.ui-state-error .ui-icon,
+.ui-state-error-text .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_cd0a0a_256x240.png)
+}
+.ui-icon-carat-1-n {
+	background-position: 0 0
+}
+.ui-icon-carat-1-ne {
+	background-position: -16px 0
+}
+.ui-icon-carat-1-e {
+	background-position: -32px 0
+}
+.ui-icon-carat-1-se {
+	background-position: -48px 0
+}
+.ui-icon-carat-1-s {
+	background-position: -64px 0
+}
+.ui-icon-carat-1-sw {
+	background-position: -80px 0
+}
+.ui-icon-carat-1-w {
+	background-position: -96px 0
+}
+.ui-icon-carat-1-nw {
+	background-position: -112px 0
+}
+.ui-icon-carat-2-n-s {
+	background-position: -128px 0
+}
+.ui-icon-carat-2-e-w {
+	background-position: -144px 0
+}
+.ui-icon-triangle-1-n {
+	background-position: 0 -16px
+}
+.ui-icon-triangle-1-ne {
+	background-position: -16px -16px
+}
+.ui-icon-triangle-1-e {
+	background-position: -32px -16px
+}
+.ui-icon-triangle-1-se {
+	background-position: -48px -16px
+}
+.ui-icon-triangle-1-s {
+	background-position: -64px -16px
+}
+.ui-icon-triangle-1-sw {
+	background-position: -80px -16px
+}
+.ui-icon-triangle-1-w {
+	background-position: -96px -16px
+}
+.ui-icon-triangle-1-nw {
+	background-position: -112px -16px
+}
+.ui-icon-triangle-2-n-s {
+	background-position: -128px -16px
+}
+.ui-icon-triangle-2-e-w {
+	background-position: -144px -16px
+}
+.ui-icon-arrow-1-n {
+	background-position: 0 -32px
+}
+.ui-icon-arrow-1-ne {
+	background-position: -16px -32px
+}
+.ui-icon-arrow-1-e {
+	background-position: -32px -32px
+}
+.ui-icon-arrow-1-se {
+	background-position: -48px -32px
+}
+.ui-icon-arrow-1-s {
+	background-position: -64px -32px
+}
+.ui-icon-arrow-1-sw {
+	background-position: -80px -32px
+}
+.ui-icon-arrow-1-w {
+	background-position: -96px -32px
+}
+.ui-icon-arrow-1-nw {
+	background-position: -112px -32px
+}
+.ui-icon-arrow-2-n-s {
+	background-position: -128px -32px
+}
+.ui-icon-arrow-2-ne-sw {
+	background-position: -144px -32px
+}
+.ui-icon-arrow-2-e-w {
+	background-position: -160px -32px
+}
+.ui-icon-arrow-2-se-nw {
+	background-position: -176px -32px
+}
+.ui-icon-arrowstop-1-n {
+	background-position: -192px -32px
+}
+.ui-icon-arrowstop-1-e {
+	background-position: -208px -32px
+}
+.ui-icon-arrowstop-1-s {
+	background-position: -224px -32px
+}
+.ui-icon-arrowstop-1-w {
+	background-position: -240px -32px
+}
+.ui-icon-arrowthick-1-n {
+	background-position: 0 -48px
+}
+.ui-icon-arrowthick-1-ne {
+	background-position: -16px -48px
+}
+.ui-icon-arrowthick-1-e {
+	background-position: -32px -48px
+}
+.ui-icon-arrowthick-1-se {
+	background-position: -48px -48px
+}
+.ui-icon-arrowthick-1-s {
+	background-position: -64px -48px
+}
+.ui-icon-arrowthick-1-sw {
+	background-position: -80px -48px
+}
+.ui-icon-arrowthick-1-w {
+	background-position: -96px -48px
+}
+.ui-icon-arrowthick-1-nw {
+	background-position: -112px -48px
+}
+.ui-icon-arrowthick-2-n-s {
+	background-position: -128px -48px
+}
+.ui-icon-arrowthick-2-ne-sw {
+	background-position: -144px -48px
+}
+.ui-icon-arrowthick-2-e-w {
+	background-position: -160px -48px
+}
+.ui-icon-arrowthick-2-se-nw {
+	background-position: -176px -48px
+}
+.ui-icon-arrowthickstop-1-n {
+	background-position: -192px -48px
+}
+.ui-icon-arrowthickstop-1-e {
+	background-position: -208px -48px
+}
+.ui-icon-arrowthickstop-1-s {
+	background-position: -224px -48px
+}
+.ui-icon-arrowthickstop-1-w {
+	background-position: -240px -48px
+}
+.ui-icon-arrowreturnthick-1-w {
+	background-position: 0 -64px
+}
+.ui-icon-arrowreturnthick-1-n {
+	background-position: -16px -64px
+}
+.ui-icon-arrowreturnthick-1-e {
+	background-position: -32px -64px
+}
+.ui-icon-arrowreturnthick-1-s {
+	background-position: -48px -64px
+}
+.ui-icon-arrowreturn-1-w {
+	background-position: -64px -64px
+}
+.ui-icon-arrowreturn-1-n {
+	background-position: -80px -64px
+}
+.ui-icon-arrowreturn-1-e {
+	background-position: -96px -64px
+}
+.ui-icon-arrowreturn-1-s {
+	background-position: -112px -64px
+}
+.ui-icon-arrowrefresh-1-w {
+	background-position: -128px -64px
+}
+.ui-icon-arrowrefresh-1-n {
+	background-position: -144px -64px
+}
+.ui-icon-arrowrefresh-1-e {
+	background-position: -160px -64px
+}
+.ui-icon-arrowrefresh-1-s {
+	background-position: -176px -64px
+}
+.ui-icon-arrow-4 {
+	background-position: 0 -80px
+}
+.ui-icon-arrow-4-diag {
+	background-position: -16px -80px
+}
+.ui-icon-extlink {
+	background-position: -32px -80px
+}
+.ui-icon-newwin {
+	background-position: -48px -80px
+}
+.ui-icon-refresh {
+	background-position: -64px -80px
+}
+.ui-icon-shuffle {
+	background-position: -80px -80px
+}
+.ui-icon-transfer-e-w {
+	background-position: -96px -80px
+}
+.ui-icon-transferthick-e-w {
+	background-position: -112px -80px
+}
+.ui-icon-folder-collapsed {
+	background-position: 0 -96px
+}
+.ui-icon-folder-open {
+	background-position: -16px -96px
+}
+.ui-icon-document {
+	background-position: -32px -96px
+}
+.ui-icon-document-b {
+	background-position: -48px -96px
+}
+.ui-icon-note {
+	background-position: -64px -96px
+}
+.ui-icon-mail-closed {
+	background-position: -80px -96px
+}
+.ui-icon-mail-open {
+	background-position: -96px -96px
+}
+.ui-icon-suitcase {
+	background-position: -112px -96px
+}
+.ui-icon-comment {
+	background-position: -128px -96px
+}
+.ui-icon-person {
+	background-position: -144px -96px
+}
+.ui-icon-print {
+	background-position: -160px -96px
+}
+.ui-icon-trash {
+	background-position: -176px -96px
+}
+.ui-icon-locked {
+	background-position: -192px -96px
+}
+.ui-icon-unlocked {
+	background-position: -208px -96px
+}
+.ui-icon-bookmark {
+	background-position: -224px -96px
+}
+.ui-icon-tag {
+	background-position: -240px -96px
+}
+.ui-icon-home {
+	background-position: 0 -112px
+}
+.ui-icon-flag {
+	background-position: -16px -112px
+}
+.ui-icon-calendar {
+	background-position: -32px -112px
+}
+.ui-icon-cart {
+	background-position: -48px -112px
+}
+.ui-icon-pencil {
+	background-position: -64px -112px
+}
+.ui-icon-clock {
+	background-position: -80px -112px
+}
+.ui-icon-disk {
+	background-position: -96px -112px
+}
+.ui-icon-calculator {
+	background-position: -112px -112px
+}
+.ui-icon-zoomin {
+	background-position: -128px -112px
+}
+.ui-icon-zoomout {
+	background-position: -144px -112px
+}
+.ui-icon-search {
+	background-position: -160px -112px
+}
+.ui-icon-wrench {
+	background-position: -176px -112px
+}
+.ui-icon-gear {
+	background-position: -192px -112px
+}
+.ui-icon-heart {
+	background-position: -208px -112px
+}
+.ui-icon-star {
+	background-position: -224px -112px
+}
+.ui-icon-link {
+	background-position: -240px -112px
+}
+.ui-icon-cancel {
+	background-position: 0 -128px
+}
+.ui-icon-plus {
+	background-position: -16px -128px
+}
+.ui-icon-plusthick {
+	background-position: -32px -128px
+}
+.ui-icon-minus {
+	background-position: -48px -128px
+}
+.ui-icon-minusthick {
+	background-position: -64px -128px
+}
+.ui-icon-close {
+	background-position: -80px -128px
+}
+.ui-icon-closethick {
+	background-position: -96px -128px
+}
+.ui-icon-key {
+	background-position: -112px -128px
+}
+.ui-icon-lightbulb {
+	background-position: -128px -128px
+}
+.ui-icon-scissors {
+	background-position: -144px -128px
+}
+.ui-icon-clipboard {
+	background-position: -160px -128px
+}
+.ui-icon-copy {
+	background-position: -176px -128px
+}
+.ui-icon-contact {
+	background-position: -192px -128px
+}
+.ui-icon-image {
+	background-position: -208px -128px
+}
+.ui-icon-video {
+	background-position: -224px -128px
+}
+.ui-icon-script {
+	background-position: -240px -128px
+}
+.ui-icon-alert {
+	background-position: 0 -144px
+}
+.ui-icon-info {
+	background-position: -16px -144px
+}
+.ui-icon-notice {
+	background-position: -32px -144px
+}
+.ui-icon-help {
+	background-position: -48px -144px
+}
+.ui-icon-check {
+	background-position: -64px -144px
+}
+.ui-icon-bullet {
+	background-position: -80px -144px
+}
+.ui-icon-radio-off {
+	background-position: -96px -144px
+}
+.ui-icon-radio-on {
+	background-position: -112px -144px
+}
+.ui-icon-pin-w {
+	background-position: -128px -144px
+}
+.ui-icon-pin-s {
+	background-position: -144px -144px
+}
+.ui-icon-play {
+	background-position: 0 -160px
+}
+.ui-icon-pause {
+	background-position: -16px -160px
+}
+.ui-icon-seek-next {
+	background-position: -32px -160px
+}
+.ui-icon-seek-prev {
+	background-position: -48px -160px
+}
+.ui-icon-seek-end {
+	background-position: -64px -160px
+}
+.ui-icon-seek-start {
+	background-position: -80px -160px
+}
+.ui-icon-seek-first {
+	background-position: -80px -160px
+}
+.ui-icon-stop {
+	background-position: -96px -160px
+}
+.ui-icon-eject {
+	background-position: -112px -160px
+}
+.ui-icon-volume-off {
+	background-position: -128px -160px
+}
+.ui-icon-volume-on {
+	background-position: -144px -160px
+}
+.ui-icon-power {
+	background-position: 0 -176px
+}
+.ui-icon-signal-diag {
+	background-position: -16px -176px
+}
+.ui-icon-signal {
+	background-position: -32px -176px
+}
+.ui-icon-battery-0 {
+	background-position: -48px -176px
+}
+.ui-icon-battery-1 {
+	background-position: -64px -176px
+}
+.ui-icon-battery-2 {
+	background-position: -80px -176px
+}
+.ui-icon-battery-3 {
+	background-position: -96px -176px
+}
+.ui-icon-circle-plus {
+	background-position: 0 -192px
+}
+.ui-icon-circle-minus {
+	background-position: -16px -192px
+}
+.ui-icon-circle-close {
+	background-position: -32px -192px
+}
+.ui-icon-circle-triangle-e {
+	background-position: -48px -192px
+}
+.ui-icon-circle-triangle-s {
+	background-position: -64px -192px
+}
+.ui-icon-circle-triangle-w {
+	background-position: -80px -192px
+}
+.ui-icon-circle-triangle-n {
+	background-position: -96px -192px
+}
+.ui-icon-circle-arrow-e {
+	background-position: -112px -192px
+}
+.ui-icon-circle-arrow-s {
+	background-position: -128px -192px
+}
+.ui-icon-circle-arrow-w {
+	background-position: -144px -192px
+}
+.ui-icon-circle-arrow-n {
+	background-position: -160px -192px
+}
+.ui-icon-circle-zoomin {
+	background-position: -176px -192px
+}
+.ui-icon-circle-zoomout {
+	background-position: -192px -192px
+}
+.ui-icon-circle-check {
+	background-position: -208px -192px
+}
+.ui-icon-circlesmall-plus {
+	background-position: 0 -208px
+}
+.ui-icon-circlesmall-minus {
+	background-position: -16px -208px
+}
+.ui-icon-circlesmall-close {
+	background-position: -32px -208px
+}
+.ui-icon-squaresmall-plus {
+	background-position: -48px -208px
+}
+.ui-icon-squaresmall-minus {
+	background-position: -64px -208px
+}
+.ui-icon-squaresmall-close {
+	background-position: -80px -208px
+}
+.ui-icon-grip-dotted-vertical {
+	background-position: 0 -224px
+}
+.ui-icon-grip-dotted-horizontal {
+	background-position: -16px -224px
+}
+.ui-icon-grip-solid-vertical {
+	background-position: -32px -224px
+}
+.ui-icon-grip-solid-horizontal {
+	background-position: -48px -224px
+}
+.ui-icon-gripsmall-diagonal-se {
+	background-position: -64px -224px
+}
+.ui-icon-grip-diagonal-se {
+	background-position: -80px -224px
+}
+.ui-corner-tl {
+	-moz-border-radius-topleft: 2px;
+	-webkit-border-top-left-radius: 2px;
+	border-top-left-radius: 2px
+}
+.ui-corner-tr {
+	-moz-border-radius-topright: 2px;
+	-webkit-border-top-right-radius: 2px;
+	border-top-right-radius: 2px
+}
+.ui-corner-bl {
+	-moz-border-radius-bottomleft: 2px;
+	-webkit-border-bottom-left-radius: 2px;
+	border-bottom-left-radius: 2px
+}
+.ui-corner-br {
+	-moz-border-radius-bottomright: 2px;
+	-webkit-border-bottom-right-radius: 2px;
+	border-bottom-right-radius: 2px
+}
+.ui-corner-top {
+	-moz-border-radius-topleft: 2px;
+	-webkit-border-top-left-radius: 2px;
+	border-top-left-radius: 2px;
+	-moz-border-radius-topright: 2px;
+	-webkit-border-top-right-radius: 2px;
+	border-top-right-radius: 2px
+}
+.ui-corner-bottom {
+	-moz-border-radius-bottomleft: 2px;
+	-webkit-border-bottom-left-radius: 2px;
+	border-bottom-left-radius: 2px;
+	-moz-border-radius-bottomright: 2px;
+	-webkit-border-bottom-right-radius: 2px;
+	border-bottom-right-radius: 2px
+}
+.ui-corner-right {
+	-moz-border-radius-topright: 2px;
+	-webkit-border-top-right-radius: 2px;
+	border-top-right-radius: 2px;
+	-moz-border-radius-bottomright: 2px;
+	-webkit-border-bottom-right-radius: 2px;
+	border-bottom-right-radius: 2px
+}
+.ui-corner-left {
+	-moz-border-radius-topleft: 2px;
+	-webkit-border-top-left-radius: 2px;
+	border-top-left-radius: 2px;
+	-moz-border-radius-bottomleft: 2px;
+	-webkit-border-bottom-left-radius: 2px;
+	border-bottom-left-radius: 2px
+}
+.ui-corner-all {
+	-moz-border-radius: 2px;
+	-webkit-border-radius: 2px;
+	border-radius: 2px
+}
+.ui-widget-overlay {
+	background: #aaa url(../images/jquery_ui/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x;
+	opacity: .3;
+	filter: Alpha(Opacity=30)
+}
+.ui-widget-shadow {
+	margin: -8px 0 0 -8px;
+	padding: 8px;
+	background: #aaa url(../images/jquery_ui/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x;
+	opacity: .3;
+	filter: Alpha(Opacity=30);
+	-moz-border-radius: 8px;
+	-webkit-border-radius: 8px;
+	border-radius: 8px
+}
+.ui-resizable {
+	position: relative
+}
+.ui-resizable-handle {
+	position: absolute;
+	font-size: .1px;
+	z-index: 99999;
+	display: block
+}
+.ui-resizable-autohide .ui-resizable-handle,
+.ui-resizable-disabled .ui-resizable-handle {
+	display: none
+}
+.ui-resizable-n {
+	cursor: n-resize;
+	height: 7px;
+	width: 100%;
+	top: -5px;
+	left: 0
+}
+.ui-resizable-s {
+	cursor: s-resize;
+	height: 7px;
+	width: 100%;
+	bottom: -5px;
+	left: 0
+}
+.ui-resizable-e {
+	cursor: e-resize;
+	width: 7px;
+	right: -5px;
+	top: 0;
+	height: 100%
+}
+.ui-resizable-w {
+	cursor: w-resize;
+	width: 7px;
+	left: -5px;
+	top: 0;
+	height: 100%
+}
+.ui-resizable-se {
+	cursor: se-resize;
+	width: 12px;
+	height: 12px;
+	right: 1px;
+	bottom: 1px
+}
+.ui-resizable-sw {
+	cursor: sw-resize;
+	width: 9px;
+	height: 9px;
+	left: -5px;
+	bottom: -5px
+}
+.ui-resizable-nw {
+	cursor: nw-resize;
+	width: 9px;
+	height: 9px;
+	left: -5px;
+	top: -5px
+}
+.ui-resizable-ne {
+	cursor: ne-resize;
+	width: 9px;
+	height: 9px;
+	right: -5px;
+	top: -5px
+}
+.ui-selectable-helper {
+	position: absolute;
+	z-index: 100;
+	border: 1px dotted #000
+}
+.ui-accordion {
+	width: 100%
+}
+.ui-accordion .ui-accordion-header {
+	cursor: pointer;
+	position: relative;
+	margin-top: 1px;
+	zoom: 1
+}
+.ui-accordion .ui-accordion-li-fix {
+	display: inline
+}
+.ui-accordion .ui-accordion-header-active {
+	border-bottom: 0!important
+}
+.ui-accordion .ui-accordion-header a {
+	display: block;
+	font-size: 1em;
+	padding: .5em .5em .5em .7em
+}
+.ui-accordion-icons .ui-accordion-header a {
+	padding-left: 2.2em
+}
+.ui-accordion .ui-accordion-header .ui-icon {
+	position: absolute;
+	left: .5em;
+	top: 50%;
+	margin-top: -8px
+}
+.ui-accordion .ui-accordion-content {
+	padding: 1em 2.2em;
+	border-top: 0;
+	margin-top: -2px;
+	position: relative;
+	top: 1px;
+	margin-bottom: 2px;
+	overflow: auto;
+	display: none;
+	zoom: 1
+}
+.ui-accordion .ui-accordion-content-active {
+	display: block
+}
+.ui-autocomplete {
+	position: absolute;
+	cursor: default
+}
+* html .ui-autocomplete {
+	width: 1px
+}
+.ui-menu {
+	list-style: none;
+	padding: 2px;
+	margin: 0;
+	display: block;
+	float: left
+}
+.ui-menu .ui-menu {
+	margin-top: -3px
+}
+.ui-menu .ui-menu-item {
+	margin: 0;
+	padding: 0;
+	zoom: 1;
+	float: left;
+	clear: left;
+	width: 100%
+}
+.ui-menu .ui-menu-item a {
+	text-decoration: none;
+	display: block;
+	padding: .2em .4em;
+	line-height: 1.5;
+	zoom: 1
+}
+.ui-menu .ui-menu-item a.ui-state-active,
+.ui-menu .ui-menu-item a.ui-state-hover {
+	font-weight: 400;
+	margin: -1px
+}
+.ui-button {
+	display: inline-block;
+	position: relative;
+	padding: 0;
+	margin-right: .1em;
+	text-decoration: none!important;
+	cursor: pointer;
+	text-align: center;
+	zoom: 1;
+	overflow: visible
+}
+.ui-button-icon-only {
+	width: 2.2em
+}
+button.ui-button-icon-only {
+	width: 2.4em
+}
+.ui-button-icons-only {
+	width: 3.4em
+}
+button.ui-button-icons-only {
+	width: 3.7em
+}
+.ui-button .ui-button-text {
+	display: block;
+	line-height: 1.4
+}
+.ui-button-icon-only .ui-button-text,
+.ui-button-icons-only .ui-button-text {
+	padding: .4em;
+	text-indent: -9999999px
+}
+.ui-button-text-icon-primary .ui-button-text,
+.ui-button-text-icons .ui-button-text {
+	padding: .4em 1em .4em 2.1em
+}
+.ui-button-text-icon-secondary .ui-button-text,
+.ui-button-text-icons .ui-button-text {
+	padding: .4em 2.1em .4em 1em
+}
+.ui-button-text-icons .ui-button-text {
+	padding-left: 2.1em;
+	padding-right: 2.1em
+}
+input.ui-button {
+	padding: .4em 1em
+}
+.ui-button-icon-only .ui-icon,
+.ui-button-icons-only .ui-icon,
+.ui-button-text-icon-primary .ui-icon,
+.ui-button-text-icon-secondary .ui-icon,
+.ui-button-text-icons .ui-icon {
+	position: absolute;
+	top: 50%;
+	margin-top: -8px
+}
+.ui-button-icon-only .ui-icon {
+	left: 50%;
+	margin-left: -8px
+}
+.ui-button-icons-only .ui-button-icon-primary,
+.ui-button-text-icon-primary .ui-button-icon-primary,
+.ui-button-text-icons .ui-button-icon-primary {
+	left: .5em
+}
+.ui-button-icons-only .ui-button-icon-secondary,
+.ui-button-text-icon-secondary .ui-button-icon-secondary,
+.ui-button-text-icons .ui-button-icon-secondary {
+	right: .5em
+}
+.ui-button-icons-only .ui-button-icon-secondary,
+.ui-button-text-icons .ui-button-icon-secondary {
+	right: .5em
+}
+.ui-buttonset {
+	margin-right: 5px
+}
+.ui-buttonset .ui-button {
+	margin: 0 3px;
+	background: #fafafa;
+	border: 1px solid #d5d5d5;
+	line-height: 14px;
+	font-size: 11px
+}
+button.ui-button::-moz-focus-inner {
+	border: 0;
+	padding: 0
+}
+.ui-dialog {
+	position: absolute;
+	padding: .2em;
+	width: 300px;
+	overflow: hidden
+}
+.ui-dialog .ui-dialog-titlebar {
+	position: relative
+}
+.ui-dialog .ui-dialog-title {
+	float: left;
+	height: 38px;
+	font-size: 16px;
+	padding: 0 12px 0 12px;
+	line-height: 38px
+}
+.ui-dialog .ui-dialog-titlebar-close {
+	position: absolute;
+	right: 6px;
+	top: 50%;
+	width: 19px;
+	margin: -10px 0 0 0;
+	padding: 1px;
+	height: 18px
+}
+.ui-dialog .ui-dialog-titlebar-close span {
+	display: block;
+	margin: 1px
+}
+.ui-dialog .ui-dialog-titlebar-close:focus,
+.ui-dialog .ui-dialog-titlebar-close:hover {
+	padding: 1px;
+	background: #fafafa
+}
+.ui-dialog .ui-dialog-content {
+	position: relative;
+	border: 0;
+	padding: .5em 1em;
+	background: 0 0;
+	overflow: auto;
+	zoom: 1
+}
+.ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset {
+	float: right
+}
+.ui-dialog .ui-dialog-buttonpane button {
+	font-size: 10px;
+	font-weight: 700;
+	text-transform: uppercase;
+	padding: 3px 12px 4px 12px;
+	cursor: pointer;
+	font-family: Arial, Helvetica, sans-serif;
+	border: 1px solid #d5d5d5;
+	color: #525252;
+	margin: 5px
+}
+.ui-dialog .ui-resizable-se {
+	width: 14px;
+	height: 14px;
+	right: 3px;
+	bottom: 3px
+}
+.ui-draggable .ui-dialog-titlebar {
+	cursor: move
+}
+.ui-slider {
+	position: relative;
+	text-align: left
+}
+.ui-slider .ui-slider-handle {
+	position: absolute;
+	z-index: 2;
+	width: 16px;
+	height: 16px;
+	cursor: default;
+	background: url(../images/ui/handle.png) no-repeat;
+	border: none;
+	cursor: pointer
+}
+.ui-slider .ui-slider-range {
+	position: absolute;
+	z-index: 1;
+	font-size: .7em;
+	display: block;
+	border: 0;
+	background: url(../images/ui/sliderOverlay.png) repeat-x;
+	-moz-border-radius: 4px;
+	-webkit-border-radius: 4px;
+	-khtml-border-radius: 4px;
+	border-radius: 4px
+}
+.ui-slider-horizontal {
+	height: 6px;
+	background: url(../images/ui/sliderBg.png) repeat-x;
+	clear: both;
+	margin-top: 10px
+}
+.ui-slider-horizontal .ui-slider-handle {
+	top: -5px;
+	margin-left: -.6em
+}
+.ui-slider-horizontal .ui-slider-range {
+	top: 0;
+	height: 100%
+}
+.ui-slider-horizontal .ui-slider-range-min {
+	left: 0
+}
+.ui-slider-horizontal .ui-slider-range-max {
+	right: 0
+}
+.ui-slider-vertical {
+	width: 6px;
+	height: 100px;
+	background: url(../images/ui/sliderBgVert.png) repeat-y
+}
+.ui-slider-vertical .ui-slider-handle {
+	left: -5px;
+	margin-left: 0;
+	margin-bottom: -.6em
+}
+.ui-slider-vertical .ui-slider-range {
+	left: 0;
+	width: 100%;
+	background: url(../images/ui/sliderOverlayVert.png) repeat-y
+}
+.ui-slider-vertical .ui-slider-range-min {
+	bottom: 0
+}
+.ui-slider-vertical .ui-slider-range-max {
+	top: 0
+}
+.ui-tabs {
+	position: relative;
+	padding: .2em;
+	zoom: 1
+}
+.ui-tabs .ui-tabs-nav {
+	margin: 0;
+	padding: .2em .2em 0
+}
+.ui-tabs .ui-tabs-nav li {
+	list-style: none;
+	float: left;
+	position: relative;
+	top: 1px;
+	margin: 0 .2em 1px 0;
+	border-bottom: 0!important;
+	padding: 0;
+	white-space: nowrap
+}
+.ui-tabs .ui-tabs-nav li a {
+	float: left;
+	padding: .5em 1em;
+	text-decoration: none
+}
+.ui-tabs .ui-tabs-nav li.ui-tabs-selected {
+	margin-bottom: 0;
+	padding-bottom: 1px
+}
+.ui-tabs .ui-tabs-nav li.ui-state-disabled a,
+.ui-tabs .ui-tabs-nav li.ui-state-processing a,
+.ui-tabs .ui-tabs-nav li.ui-tabs-selected a {
+	cursor: text
+}
+.ui-tabs .ui-tabs-nav li a,
+.ui-tabs.ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-selected a {
+	cursor: pointer
+}
+.ui-tabs .ui-tabs-panel {
+	display: block;
+	border-width: 0;
+	padding: 1em 1.4em;
+	background: 0 0
+}
+.ui-tabs .ui-tabs-hide {
+	display: none!important
+}
+.datepicker {
+	width: 70px!important
+}
+.ui-datepicker {
+	width: 17em;
+	padding: .2em .2em 0;
+	border: 1px solid #d5d5d5;
+	background: #fafafa;
+	margin-top: 1px;
+	z-index: 3;
+	display: none
+}
+.ui-datepicker-append {
+	margin-left: 10px
+}
+.ui-datepicker .ui-datepicker-header {
+	position: relative;
+	padding: .2em 0;
+	border: 1px solid #e7e7e7;
+	background: url(../images/leftNavBg.png) repeat-x
+}
+.ui-datepicker .ui-datepicker-next,
+.ui-datepicker .ui-datepicker-prev {
+	position: absolute;
+	top: 2px;
+	width: 1.8em;
+	height: 1.8em
+}
+.ui-datepicker .ui-datepicker-next-hover,
+.ui-datepicker .ui-datepicker-prev-hover {
+	top: 1px
+}
+.ui-datepicker .ui-datepicker-prev {
+	left: 2px
+}
+.ui-datepicker .ui-datepicker-next {
+	right: 2px
+}
+.ui-datepicker .ui-datepicker-prev-hover {
+	left: 1px
+}
+.ui-datepicker .ui-datepicker-next-hover {
+	right: 1px
+}
+.ui-datepicker .ui-datepicker-next span,
+.ui-datepicker .ui-datepicker-prev span {
+	display: block;
+	position: absolute;
+	left: 50%;
+	margin-left: -8px;
+	top: 50%;
+	margin-top: -8px
+}
+.ui-datepicker .ui-datepicker-title {
+	margin: 0 2.3em;
+	line-height: 1.8em;
+	text-align: center
+}
+.ui-datepicker .ui-datepicker-title select {
+	font-size: 1em;
+	margin: 1px 0
+}
+.ui-datepicker select.ui-datepicker-month-year {
+	width: 100%
+}
+.ui-datepicker select.ui-datepicker-month,
+.ui-datepicker select.ui-datepicker-year {
+	width: 49%
+}
+.ui-datepicker table {
+	width: 100%;
+	font-size: .9em;
+	border-collapse: collapse;
+	margin: 0 0 .4em
+}
+.ui-datepicker table .ui-state-default {
+	border: 1px solid #d5d5d5
+}
+.ui-datepicker table tbody {
+	font-size: 11px
+}
+.ui-datepicker th {
+	padding: .7em .3em;
+	text-align: center;
+	font-weight: 700;
+	border: 0
+}
+.ui-datepicker td {
+	border: 0;
+	padding: 1px
+}
+.ui-datepicker td a,
+.ui-datepicker td span {
+	display: block;
+	padding: .2em;
+	text-align: right;
+	text-decoration: none
+}
+.ui-datepicker .ui-datepicker-buttonpane {
+	background-image: none;
+	margin: .7em 0 0 0;
+	padding: 0 .2em;
+	border-left: 0;
+	border-right: 0;
+	border-bottom: 0
+}
+.ui-datepicker .ui-datepicker-buttonpane button {
+	float: right;
+	margin: .5em .2em .4em;
+	cursor: pointer;
+	padding: .2em .6em .3em .6em;
+	width: auto;
+	overflow: visible
+}
+.ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current {
+	float: left
+}
+.ui-datepicker.ui-datepicker-multi {
+	width: auto
+}
+.ui-datepicker-multi .ui-datepicker-group {
+	float: left
+}
+.ui-datepicker-multi .ui-datepicker-group table {
+	width: 95%;
+	margin: 0 auto .4em
+}
+.ui-datepicker-multi-2 .ui-datepicker-group {
+	width: 50%
+}
+.ui-datepicker-multi-3 .ui-datepicker-group {
+	width: 33.3%
+}
+.ui-datepicker-multi-4 .ui-datepicker-group {
+	width: 25%
+}
+.ui-datepicker-multi .ui-datepicker-group-last .ui-datepicker-header {
+	border-left-width: 0
+}
+.ui-datepicker-multi .ui-datepicker-group-middle .ui-datepicker-header {
+	border-left-width: 0
+}
+.ui-datepicker-multi .ui-datepicker-buttonpane {
+	clear: left
+}
+.ui-datepicker-row-break {
+	clear: both;
+	width: 100%
+}
+.ui-datepicker-rtl {
+	direction: rtl
+}
+.ui-datepicker-rtl .ui-datepicker-prev {
+	right: 2px;
+	left: auto
+}
+.ui-datepicker-rtl .ui-datepicker-next {
+	left: 2px;
+	right: auto
+}
+.ui-datepicker-rtl .ui-datepicker-prev:hover {
+	right: 1px;
+	left: auto
+}
+.ui-datepicker-rtl .ui-datepicker-next:hover {
+	left: 1px;
+	right: auto
+}
+.ui-datepicker-rtl .ui-datepicker-buttonpane {
+	clear: right
+}
+.ui-datepicker-rtl .ui-datepicker-buttonpane button {
+	float: left
+}
+.ui-datepicker-rtl .ui-datepicker-buttonpane button.ui-datepicker-current {
+	float: right
+}
+.ui-datepicker-rtl .ui-datepicker-group {
+	float: right
+}
+.ui-datepicker-rtl .ui-datepicker-group-last .ui-datepicker-header {
+	border-right-width: 0;
+	border-left-width: 1px
+}
+.ui-datepicker-rtl .ui-datepicker-group-middle .ui-datepicker-header {
+	border-right-width: 0;
+	border-left-width: 1px
+}
+.ui-progressbar {
+	height: 16px;
+	text-align: left;
+	margin-top: 5px;
+	background: url(../images/ui/progress.png) repeat-x
+}
+.ui-progressbar .ui-progressbar-value {
+	margin: 0;
+	height: 100%;
+	overflow: hidden;
+	display: block;
+	background: url(../images/ui/progressOverlay.png) repeat-x;
+	border-right: 1px solid #3c95d8
+}
+.pbar .ui-progressbar-value {
+	display: block!important
+}
+.pbar {
+	overflow: hidden;
+	background: url(../images/ui/progress.png) repeat-x
+}
+.percent {
+	position: relative;
+	text-align: right;
+	margin-bottom: 5px;
+	font-size: 11px
+}
+.elapsed {
+	position: relative;
+	text-align: right;
+	margin-top: 5px;
+	font-size: 11px
+}
+.ui-autocomplete {
+	position: absolute;
+	cursor: default
+}
+* html .ui-autocomplete {
+	width: 1px
+}
+.ui-menu {
+	list-style: none;
+	padding: 2px;
+	margin: 0;
+	display: block;
+	float: left;
+	border: 1px solid #3c4049;
+	border-top: 0;
+	z-index: 11
+}
+.ui-menu .ui-menu {
+	margin-top: -3px
+}
+.ui-menu .ui-menu-item {
+	margin: 0;
+	padding: 0;
+	zoom: 1;
+	float: left;
+	clear: left;
+	width: 100%;
+	background-color: #f5f5f5
+}
+.ui-menu .ui-menu-item a {
+	text-decoration: none;
+	display: block;
+	line-height: 1.5
+}
+.ui-menu .ui-menu-item a.ui-state-active,
+.ui-menu .ui-menu-item a.ui-state-hover {
+	font-weight: 700
+}
+.breadCrumbHolder.module {
+	margin-top: 0
+}
+.pagination {
+	margin-top: 40px;
+	margin-bottom: 40px
+}
+.mainForm input[type=email] {
+	background: #fff;
+	width: 100%;
+	border: 1px solid #d5d5d5;
+	padding: 5px;
+	font-size: 11px;
+	font-family: Arial, Helvetica, sans-serif;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-ms-box-sizing: border-box;
+	box-sizing: border-box
+}
+div.help {
+	border-bottom: 1px solid #e7e7e7;
+	margin: 10px 0 0;
+	padding: 10px 12px
+}
+div.help h3 {
+	font-size: 1.5em;
+	margin-bottom: 5px
+}
+div.help blockquote {
+	margin: 5px 0;
+	line-height: 1.5em;
+	padding: 5px;
+	border: 0;
+	text-align: left
+}
+.tableStatic thead th {
+	padding: 3px 0 2px 0;
+	text-align: center;
+	border-left: 1px solid #d5d5d5;
+	background: #efefef url(../images/leftNavBg.png) repeat-x;
+	border-bottom: 1px solid #d5d5d5;
+	font-size: 11px;
+	color: #878787
+}
+.tableStatic.with-tbb {
+	border-top: 1px solid #d5d5d5;
+	border-bottom: 1px solid #d5d5d5
+}
+.tableStatic tfoot tr td,
+.tableStatic tfoot tr th {
+	padding: 8px 10px
+}
+.tableStatic tfoot tr td:first-child,
+.tableStatic tfoot tr th:first-child {
+	border-top: 1px solid #e7e7e7
+}
+.mainForm fieldset legend {
+	margin: 10px 0 0;
+	padding: 10px 12px;
+	font-size: 1.2em
+}
+.moreFields ul li.sep.txt {
+	color: inherit
+}
+.widget .head h5.no-icon {
+	padding-left: 9px
+}
+.conversation ul.tabs li span {
+	display: block;
+	margin: 10px 0 0 0;
+	padding-right: 5px;
+	float: left;
+	width: 16px;
+	height: 16px;
+	background-position: 0 0
+}
+.conversation .gravatar {
+	padding-top: 1px;
+	margin-right: 10px;
+	float: left
+}
+.conversation form textarea {
+	margin-bottom: 22px
+}
+.conversation .message .body {
+	overflow: auto
+}
+.conversation .message blockquote {
+	overflow: auto;
+	width: 97%
+}
+.conversation .canned_response {
+	float: right;
+	margin: 0 2px 22px 0
+}
+.dim {
+	height: 100%;
+	width: 100%;
+	position: fixed;
+	left: 0;
+	top: 0;
+	z-index: 1!important;
+	background-color: #fff;
+	display: none;
+	-khtml-opacity: .5;
+	-moz-opacity: .5;
+	opacity: .5
+}
+table.pp td {
+	border-top: 1px solid #e7e7e7;
+	padding: 10px 14px 10px 14px;
+	margin: 12px 12px 12px 0;
+	position: relative;
+	height: 10px
+}
+table.pp label {
+	padding: 0;
+	width: 130px
+}
+div.vars div.var_category {
+	float: left;
+	width: 50%
+}
+div.vars div.var_category h1 {
+	padding: 0 0 0 10px
+}
+div.vars div.var_category ul {
+	list-style-position: inside;
+	margin: 10px;
+	padding: 10px;
+	border: solid 1px #ccc;
+	background-color: #fff
+}
+div.bull {
+	width: 11px;
+	height: 10px;
+	display: block;
+	float: left;
+	margin-top: 4px
+}
+div.bull.charge.yes,
+div.bull.task.executed {
+	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAKCAQAAADI+WwIAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dEAP+Hj8y/AAAACXBIWXMAAAsTAAALEwEAmpwYAAAACXZwQWcAAAALAAAACgCF+qVAAAAAhUlEQVQI103NMQqCABgF4C+Fxg7QHDQ0JkFnaKqlKJBu4Np9hEDoBq2doCYP0B4UBKLYUKZvex+P/+9N/dJ3FXl9S9CopbF9U1pOkAgb3irVanOMlGqldeBoo9CmspMFOFmp/hzLmtuXzvrWvpwJFVJvLLqci8Qmzl8OhzBwcMdD6ilXfwAd9B9f78yTCQAAAABJRU5ErkJggg==)
+}
+div.bull.task.pending_setup {
+	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAKCAQAAADI+WwIAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAACxIAAAsSAdLdfvwAAAAJdnBBZwAAAAsAAAAKAIX6pUAAAACTSURBVAjXTY0xCsJAEEVfdiEgpPAWFpYTvMRWSioDwdIuh7GydbEIeAM7sU1lo42tR1CEdSzMJk4178H/H7qTVK4+A0URTNTMmZhVhEHXMK69/UEiS3Z0sOGOQqBMQAr2pABbgKDlujHQHlgQYpdWeRO7z/0Cj8swOcPyxvOEl/vXN/K2+kw5Zq4PipNR/E+Ft8IX7yMjsFUGo0cAAAAcdEVYdFNvZnR3YXJlAEFkb2JlIEZpcmV3b3JrcyBDUzVxteM2AAAAAElFTkSuQmCC)
+}
+div.bull.charge.no,
+div.bull.task.pending_payment {
+	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAKCAQAAADI+WwIAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dEAP+Hj8y/AAAACXBIWXMAAAsTAAALEwEAmpwYAAAACXZwQWcAAAALAAAACgCF+qVAAAAAo0lEQVQI1z2NMQrCQBRE32YxGFDwBGJnYZkll0ilpDISLO28k4lFwN7CTsTKSisbK8ELCJFI/BZJdn41j/kzSqiVuZ3r1yzeAAanoajpcOwsW2dxf+0yWGe6CaVzNmgY4VHyQKAiVsIlUlvc9otK4lXugNnJjKqlkpi86X6exIZfNztZBGhKUgr4hBZ3A3UX4ye/CYdeWHch7MOzJ9R3jFLt8we7izGyoi32iQAAAABJRU5ErkJggg==)
+}
+#theme-settings h3.section-header {
+	padding: 2px 5px 2px 10px;
+	font-size: 14px;
+	background: #eee;
+	border-bottom: 1px solid #ccc;
+	color: #333;
+	margin-bottom: 1px;
+	background-image: url(../images/arrows.png);
+	background-position: 98% 10px;
+	background-repeat: no-repeat
+}
+#theme-settings h3.section-header.collapsed {
+	background-position: 98% -96px
+}
+#theme-settings h3.section-header:hover {
+	background-color: #e6f0f5;
+	border-bottom-color: #cfdce4;
+	background-position: 98% -18px;
+	cursor: pointer
+}
+#theme-settings h3.section-header.collapsed:hover {
+	background-position: 98% -124px
+}
+#theme-settings fieldset {
+	padding: 15px;
+	display: none;
+	background-color: #fdfdfd
+}
+#theme-settings fieldset legend {
+	display: none
+}
+#theme-settings fieldset h3 {
+	font-size: 13px;
+	font-weight: 700;
+	color: #444;
+	padding: 5px 0 5px 0
+}
+#theme-settings table {
+	border-spacing: 2px;
+	margin-left: 10px
+}
+#theme-settings table td {
+	vertical-align: middle;
+	padding-bottom: 5px
+}
+#theme-settings fieldset>table>tbody>tr>td:first-child {
+	width: 250px;
+	vertical-align: top
+}
+#theme-settings p {
+	margin: 0 10px
+}
+#theme-settings hr {
+	background: #d5d5d5;
+	width: 100%;
+	height: 1px;
+	font-size: 1px;
+	border: 0
+}
+#theme-settings .actions {
+	padding: 10px;
+	border-top: 1px solid #d5d5d5
+}
+#theme-settings input[type=email],
+#theme-settings input[type=password],
+#theme-settings input[type=text],
+#theme-settings textarea {
+	padding: 2px;
+	border: 1px solid #ccc;
+	font-family: monospace;
+	font-size: 9pt
+}
+#theme-settings input.long,
+#theme-settings textarea.long {
+	width: 350px
+}
+#theme-settings input.color {
+	width: 50px;
+	margin-right: 5px
+}
+.sp-boxbilling {
+	padding: 1px!important;
+	border: 0!important;
+	background: #ccc!important
+}
+.sp-boxbilling .sp-preview {
+	margin: 0!important;
+	border: 0 solid #fff!important;
+	margin: 0!important;
+	width: 17px!important;
+	height: 17px!important
+}
+.sp-boxbilling .sp-preview-inner {
+	width: 15px!important;
+	height: 15px!important;
+	margin: 0!important;
+	border: 1px solid #fff!important
+}
+.sp-boxbilling .sp-dd {
+	display: none
+}
+.hover-row:hover {
+	background-color: #e4e4e4!important;
+	transition: background-color .2s ease-in-out;
+	-moz-transition: background-color .2s ease-in-out;
+	-webkit-transition: background-color .2s ease-in-out
+}
+.flag {
+	display: inline-block;
+	width: 16px;
+	height: 11px;
+	background: url(../images/csg-4ffefaac101ed.png) no-repeat top left
+}
+.flag- {
+	background-position: -1000px -1000px;
+	width: 16px;
+	height: 11px
+}
+.flag-AD {
+	background-position: 0 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AE {
+	background-position: -26px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AF {
+	background-position: -52px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AG {
+	background-position: -78px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AI {
+	background-position: -104px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AL {
+	background-position: -130px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AM {
+	background-position: -156px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AN {
+	background-position: -182px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AO {
+	background-position: -208px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AR {
+	background-position: -234px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AS {
+	background-position: -260px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AT {
+	background-position: -286px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AU {
+	background-position: -312px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AW {
+	background-position: -338px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AX {
+	background-position: -364px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-AZ {
+	background-position: -390px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BA {
+	background-position: -416px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BB {
+	background-position: -442px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BD {
+	background-position: -468px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BE {
+	background-position: -494px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BF {
+	background-position: -520px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BG {
+	background-position: -546px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BH {
+	background-position: -572px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BI {
+	background-position: -598px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BJ {
+	background-position: -624px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BM {
+	background-position: -650px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BN {
+	background-position: -676px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BO {
+	background-position: -702px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BR {
+	background-position: -728px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BS {
+	background-position: -754px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BT {
+	background-position: -780px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BV {
+	background-position: -806px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BW {
+	background-position: -832px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BY {
+	background-position: -858px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-BZ {
+	background-position: -884px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CA {
+	background-position: -910px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CATALONIA {
+	background-position: -936px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CC {
+	background-position: -962px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CD {
+	background-position: -988px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CF {
+	background-position: -1014px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CG {
+	background-position: -1040px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CH {
+	background-position: -1066px 0;
+	width: 11px;
+	height: 11px
+}
+.flag-CI {
+	background-position: -1087px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CK {
+	background-position: -1113px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CL {
+	background-position: -1139px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CM {
+	background-position: -1165px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CN {
+	background-position: -1191px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CO {
+	background-position: -1217px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CR {
+	background-position: -1243px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CS {
+	background-position: -1269px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CU {
+	background-position: -1295px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CV {
+	background-position: -1321px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CX {
+	background-position: -1347px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CY {
+	background-position: -1373px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-CZ {
+	background-position: -1399px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-DE {
+	background-position: -1425px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-DJ {
+	background-position: -1451px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-DK {
+	background-position: -1477px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-DM {
+	background-position: -1503px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-DO {
+	background-position: -1529px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-DZ {
+	background-position: -1555px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-EC {
+	background-position: -1581px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-EE {
+	background-position: -1607px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-EG {
+	background-position: -1633px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-EH {
+	background-position: -1659px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-ENGLAND {
+	background-position: -1685px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-ER {
+	background-position: -1711px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-ES {
+	background-position: -1737px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-ET {
+	background-position: -1763px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-EUROPEANUNION {
+	background-position: -1789px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-FI {
+	background-position: -1815px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-FJ {
+	background-position: -1841px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-FK {
+	background-position: -1867px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-FM {
+	background-position: -1893px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-FO {
+	background-position: -1919px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-FR {
+	background-position: -1945px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-GA {
+	background-position: -1971px 0;
+	width: 16px;
+	height: 11px
+}
+.flag-GB {
+	background-position: 0 -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GD {
+	background-position: -26px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GE {
+	background-position: -52px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GF {
+	background-position: -78px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GH {
+	background-position: -104px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GI {
+	background-position: -130px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GL {
+	background-position: -156px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GM {
+	background-position: -182px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GN {
+	background-position: -208px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GP {
+	background-position: -234px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GQ {
+	background-position: -260px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GR {
+	background-position: -286px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GS {
+	background-position: -312px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GT {
+	background-position: -338px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GU {
+	background-position: -364px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GW {
+	background-position: -390px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-GY {
+	background-position: -416px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-HK {
+	background-position: -442px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-HM {
+	background-position: -468px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-HN {
+	background-position: -494px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-HR {
+	background-position: -520px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-HT {
+	background-position: -546px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-HU {
+	background-position: -572px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-ID {
+	background-position: -598px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-IE {
+	background-position: -624px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-IL {
+	background-position: -650px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-IN {
+	background-position: -676px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-IO {
+	background-position: -702px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-IQ {
+	background-position: -728px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-IR {
+	background-position: -754px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-IS {
+	background-position: -780px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-IT {
+	background-position: -806px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-JM {
+	background-position: -832px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-JO {
+	background-position: -858px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-JP {
+	background-position: -884px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-KE {
+	background-position: -910px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-KG {
+	background-position: -936px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-KH {
+	background-position: -962px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-KI {
+	background-position: -988px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-KM {
+	background-position: -1014px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-KN {
+	background-position: -1040px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-KP {
+	background-position: -1066px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-KR {
+	background-position: -1092px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-KW {
+	background-position: -1118px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-KY {
+	background-position: -1144px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-KZ {
+	background-position: -1170px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-LA {
+	background-position: -1196px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-LB {
+	background-position: -1222px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-LC {
+	background-position: -1248px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-LI {
+	background-position: -1274px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-LK {
+	background-position: -1300px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-LR {
+	background-position: -1326px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-LS {
+	background-position: -1352px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-LT {
+	background-position: -1378px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-LU {
+	background-position: -1404px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-LV {
+	background-position: -1430px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-LY {
+	background-position: -1456px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MA {
+	background-position: -1482px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MC {
+	background-position: -1508px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MD {
+	background-position: -1534px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-ME {
+	background-position: -1560px -21px;
+	width: 16px;
+	height: 12px
+}
+.flag-MG {
+	background-position: -1586px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MH {
+	background-position: -1612px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MK {
+	background-position: -1638px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-ML {
+	background-position: -1664px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MM {
+	background-position: -1690px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MN {
+	background-position: -1716px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MO {
+	background-position: -1742px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MP {
+	background-position: -1768px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MQ {
+	background-position: -1794px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MR {
+	background-position: -1820px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MS {
+	background-position: -1846px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MT {
+	background-position: -1872px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MU {
+	background-position: -1898px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MV {
+	background-position: -1924px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MW {
+	background-position: -1950px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MX {
+	background-position: -1976px -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-MY {
+	background-position: 0 -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-MZ {
+	background-position: -26px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-NA {
+	background-position: -52px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-NC {
+	background-position: -78px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-NE {
+	background-position: -104px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-NF {
+	background-position: -130px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-NG {
+	background-position: -156px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-NI {
+	background-position: -182px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-NL {
+	background-position: -208px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-NO {
+	background-position: -234px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-NP {
+	background-position: -260px -43px;
+	width: 9px;
+	height: 11px
+}
+.flag-NR {
+	background-position: -279px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-NU {
+	background-position: -305px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-NZ {
+	background-position: -331px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-OM {
+	background-position: -357px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PA {
+	background-position: -383px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PE {
+	background-position: -409px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PF {
+	background-position: -435px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PG {
+	background-position: -461px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PH {
+	background-position: -487px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PK {
+	background-position: -513px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PL {
+	background-position: -539px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PM {
+	background-position: -565px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PN {
+	background-position: -591px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PR {
+	background-position: -617px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PS {
+	background-position: -643px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PT {
+	background-position: -669px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PW {
+	background-position: -695px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-PY {
+	background-position: -721px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-QA {
+	background-position: -747px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-RE {
+	background-position: -773px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-RO {
+	background-position: -799px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-RS {
+	background-position: -825px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-RU {
+	background-position: -851px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-RW {
+	background-position: -877px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SA {
+	background-position: -903px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SB {
+	background-position: -929px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SC {
+	background-position: -955px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SCOTLAND {
+	background-position: -981px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SD {
+	background-position: -1007px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SE {
+	background-position: -1033px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SG {
+	background-position: -1059px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SH {
+	background-position: -1085px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SI {
+	background-position: -1111px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SJ {
+	background-position: -1137px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SK {
+	background-position: -1163px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SL {
+	background-position: -1189px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SM {
+	background-position: -1215px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SN {
+	background-position: -1241px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SO {
+	background-position: -1267px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SR {
+	background-position: -1293px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-ST {
+	background-position: -1319px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SV {
+	background-position: -1345px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SY {
+	background-position: -1371px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-SZ {
+	background-position: -1397px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TC {
+	background-position: -1423px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TD {
+	background-position: -1449px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TF {
+	background-position: -1475px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TG {
+	background-position: -1501px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TH {
+	background-position: -1527px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TJ {
+	background-position: -1553px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TK {
+	background-position: -1579px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TL {
+	background-position: -1605px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TM {
+	background-position: -1631px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TN {
+	background-position: -1657px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TO {
+	background-position: -1683px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TR {
+	background-position: -1709px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TT {
+	background-position: -1735px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TV {
+	background-position: -1761px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TW {
+	background-position: -1787px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-TZ {
+	background-position: -1813px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-UA {
+	background-position: -1839px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-UK {
+	background-position: 0 -21px;
+	width: 16px;
+	height: 11px
+}
+.flag-UG {
+	background-position: -1865px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-UM {
+	background-position: -1891px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-US {
+	background-position: -1917px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-UY {
+	background-position: -1943px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-UZ {
+	background-position: -1969px -43px;
+	width: 16px;
+	height: 11px
+}
+.flag-VA {
+	background-position: 0 -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-VC {
+	background-position: -26px -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-VE {
+	background-position: -52px -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-VG {
+	background-position: -78px -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-VI {
+	background-position: -104px -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-VN {
+	background-position: -130px -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-VU {
+	background-position: -156px -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-WALES {
+	background-position: -182px -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-WF {
+	background-position: -208px -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-WS {
+	background-position: -234px -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-YE {
+	background-position: -260px -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-YT {
+	background-position: -286px -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-ZA {
+	background-position: -312px -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-ZM {
+	background-position: -338px -65px;
+	width: 16px;
+	height: 11px
+}
+.flag-ZW {
+	background-position: -364px -65px;
+	width: 16px;
+	height: 11px
+}
+a,
+abbr,
+acronym,
+address,
+applet,
+b,
+big,
+blockquote,
+body,
+caption,
+center,
+cite,
+code,
+dd,
+del,
+dfn,
+div,
+dl,
+dt,
+em,
+fieldset,
+font,
+form,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+html,
+i,
+iframe,
+img,
+ins,
+kbd,
+label,
+legend,
+li,
+object,
+ol,
+p,
+pre,
+q,
+s,
+samp,
+small,
+span,
+strike,
+strong,
+sub,
+sup,
+table,
+tbody,
+td,
+tfoot,
+th,
+thead,
+tr,
+tt,
+u,
+ul,
+var {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	outline: 0;
+	font-size: 100%;
+	vertical-align: baseline;
+	background: 0 0
+}
+ol,
+ul {
+	list-style: none
+}
+blockquote,
+q {
+	quotes: none
+}
+blockquote:after,
+blockquote:before,
+q:after,
+q:before {
+	content: '';
+	content: none
+}
+:focus {
+	outline: 0
+}
+ins {
+	text-decoration: none
+}
+del {
+	text-decoration: line-through
+}
+table {
+	border-collapse: collapse
+}
+*,
+* focus {
+	outline: 0;
+	margin: 0;
+	padding: 0
+}
+textarea {
+	overflow: auto
+}
+input[type=password],
+input[type=text],
+textarea {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 11px
+}
+button,
+input[type=submit] {
+	font-family: Arial, Helvetica, sans-serif
+}
+img {
+	border: 0
+}
+ul {
+	list-style: none;
+	margin: 0;
+	padding: 0
+}
+p {
+	margin: 0;
+	padding: 0
+}
+:focus {
+	outline: 0
+}
+a {
+	text-decoration: none;
+	color: #2b6893
+}
+.normal {
+	font-style: normal
+}
+.normalFont {
+	font-style: normal;
+	font-weight: 400
+}
+.mt40 {
+	margin-top: 40px
+}
+.nomargin {
+	margin: 0!important
+}
+.m10 {
+	margin: 10px 0
+}
+.m15 {
+	margin: 15px 0
+}
+.m20 {
+	margin: 20px 0
+}
+.mr5 {
+	margin-right: 5px
+}
+.mr10 {
+	margin-right: 10px
+}
+.mr15 {
+	margin-right: 15px
+}
+.mr20 {
+	margin-right: 20px
+}
+.mr25 {
+	margin-right: 25px
+}
+.mr30 {
+	margin-right: 30px
+}
+.mb0 {
+	margin-bottom: 0
+}
+.mb5 {
+	margin-bottom: 5px
+}
+.mb10 {
+	margin-bottom: 10px
+}
+.mb15 {
+	margin-bottom: 15px
+}
+.mb20 {
+	margin-bottom: 20px
+}
+.mb25 {
+	margin-bottom: 25px
+}
+.mb30 {
+	margin-bottom: 30px
+}
+.mb40 {
+	margin-bottom: 40px
+}
+.mt0 {
+	margin-top: 0
+}
+.mt5 {
+	margin-top: 5px
+}
+.mt10 {
+	margin-top: 10px
+}
+.mt12 {
+	margin-top: 12px
+}
+.mt15 {
+	margin-top: 15px
+}
+.mt20 {
+	margin-top: 20px
+}
+.mt25 {
+	margin-top: 25px
+}
+.mt30 {
+	margin-top: 30px
+}
+.ml5 {
+	margin-left: 5px
+}
+.ml10 {
+	margin-left: 10px
+}
+.ml15 {
+	margin-left: 15px
+}
+.ml20 {
+	margin-left: 20px
+}
+.ml25 {
+	margin-left: 25px
+}
+.ml30 {
+	margin-left: 30px
+}
+.mr5 {
+	margin-right: 5px
+}
+.mr10 {
+	margin-right: 10px
+}
+.mr15 {
+	margin-right: 15px
+}
+.mr20 {
+	margin-right: 20px
+}
+.mr25 {
+	margin-right: 25px
+}
+.mr30 {
+	margin-right: 30px
+}
+.pb0 {
+	padding-bottom: 0!important
+}
+.pb5 {
+	padding-bottom: 5px
+}
+.pb10 {
+	padding-bottom: 10px
+}
+.pb15 {
+	padding-bottom: 15px
+}
+.pb20 {
+	padding-bottom: 20px
+}
+.pb25 {
+	padding-bottom: 25px
+}
+.pb30 {
+	padding-bottom: 30px
+}
+.pt0 {
+	padding-top: 0
+}
+.pt5 {
+	padding-top: 5px
+}
+.pt10 {
+	padding-top: 10px
+}
+.pt15 {
+	padding-top: 15px
+}
+.pt20 {
+	padding-top: 20px
+}
+.pt25 {
+	padding-top: 25px
+}
+.pt30 {
+	padding-top: 30px
+}
+input::-moz-focus-inner {
+	border: 0;
+	padding: 0
+}
+a.button::-moz-focus-inner {
+	border: 0;
+	padding-top: 20px
+}
+.paging_two_button .ui-button {
+	float: left;
+	cursor: pointer
+}
+.paging_full_numbers .ui-button {
+	padding: 2px 6px;
+	margin: 0;
+	cursor: pointer
+}
+.dataTables_paginate .ui-button {
+	margin-right: -.1em!important
+}
+.dataTables_wrapper .ui-toolbar {
+	padding: 5px
+}
+.dataTables_paginate {
+	width: auto
+}
+.dataTables_info {
+	padding: 7px 0 0 80px;
+	color: #878787
+}
+table.display thead th {
+	padding: 4px 0 3px 10px;
+	cursor: pointer;
+	font-size: 11px
+}
+div.dataTables_wrapper .ui-widget-header {
+	font-weight: 400;
+	background: #efefef url(../images/leftNavBg.png) repeat-x;
+	border-top: 1px solid #d5d5d5;
+	margin-top: -1px;
+	border-right: none
+}
+table.display thead th div.DataTables_sort_wrapper {
+	position: relative;
+	padding-right: 20px;
+	color: #878787
+}
+table.display thead th div.DataTables_sort_wrapper span {
+	position: absolute;
+	top: 50%;
+	margin-top: -8px;
+	right: 5px
+}
+.dataTables_wrapper {
+	position: relative;
+	min-height: 302px;
+	clear: both
+}
+.dataTables_processing {
+	position: absolute;
+	top: 0;
+	left: 50%;
+	width: 250px;
+	margin-left: -125px;
+	border: 1px solid #ddd;
+	text-align: center;
+	color: #999;
+	font-size: 11px;
+	padding: 2px 0
+}
+.dataTables_length {
+	float: left;
+	color: #878787;
+	margin: 7px 5px 0 5px
+}
+.dataTables_length label {
+	padding-top: 10px;
+	font-size: 11px
+}
+.dataTables_length select {
+	font-size: 11px;
+	margin: 0 5px
+}
+.dataTables_filter {
+	text-align: left;
+	margin: 4px 8px 2px 10px;
+	position: absolute;
+	right: 0;
+	top: -34px;
+	color: #878787;
+	font-size: 11px
+}
+.dataTables_filter input[type=text] {
+	padding: 3px 5px;
+	border: 1px solid #d5d5d5;
+	width: 200px;
+	position: relative;
+	margin-left: 6px;
+	-moz-border-radius: 2px;
+	-webkit-border-radius: 2px;
+	-khtml-border-radius: 2px;
+	border-radius: 2px;
+	color: #878787
+}
+.dataTables_filter .srch {
+	position: absolute;
+	right: 6px;
+	top: 7px;
+	background: url(../images/searchSmall.png) no-repeat 0 0;
+	border: none;
+	width: 9px;
+	height: 9px
+}
+.dataTables_info {
+	float: left
+}
+.dataTables_paginate {
+	text-align: right;
+	margin: 6px
+}
+.paginate_disabled_next,
+.paginate_disabled_previous,
+.paginate_enabled_next,
+.paginate_enabled_previous {
+	height: 19px;
+	width: 19px;
+	margin-left: 3px;
+	float: left
+}
+.paginate_disabled_previous {
+	background-image: url(../images/back_disabled.jpg)
+}
+.paginate_enabled_previous {
+	background-image: url(../images/back_enabled.jpg)
+}
+.paginate_disabled_next {
+	background-image: url(../images/forward_disabled.jpg)
+}
+.paginate_enabled_next {
+	background-image: url(../images/forward_enabled.jpg)
+}
+table.display {
+	margin: 0 auto;
+	width: 100%;
+	clear: both;
+	border-collapse: collapse
+}
+table.display tfoot th {
+	padding: 3px 0 3px 10px;
+	font-weight: 700;
+	font-weight: 400
+}
+table.display tr.heading2 td {
+	border-bottom: 1px solid #aaa
+}
+table.display td {
+	padding: 8px 10px
+}
+table.display td.center {
+	text-align: center
+}
+.sorting_asc {
+	background: url(../images/sort_asc.png) no-repeat center right
+}
+.sorting_desc {
+	background: url(../images/sort_desc.png) no-repeat center right
+}
+.sorting {
+	background: url(../images/sort_both.png) no-repeat center right
+}
+.sorting_asc_disabled {
+	background: url(../images/sort_asc_disabled.png) no-repeat center right
+}
+.sorting_desc_disabled {
+	background: url(../images/sort_desc_disabled.png) no-repeat center right
+}
+table.display tr.odd.gradeA {
+	background-color: #dfd
+}
+table.display tr.even.gradeA {
+	background-color: #efe
+}
+table.display tr {
+	border-bottom: 1px solid #e7e7e7
+}
+table.display td {
+	border-left: 1px solid #e7e7e7
+}
+table.display td:first-child {
+	border-left: none
+}
+table.display tr.odd.gradeA {
+	background-color: #fafafa
+}
+table.display tr.even.gradeA {
+	background-color: #f5f5f5
+}
+table.display tr.odd.gradeC {
+	background-color: #ddf
+}
+table.display tr.even.gradeC {
+	background-color: #eef
+}
+table.display tr.odd.gradeX {
+	background-color: #fdd
+}
+table.display tr.even.gradeX {
+	background-color: #fee
+}
+table.display tr.odd.gradeU {
+	background-color: #ddd
+}
+table.display tr.even.gradeU {
+	background-color: #eee
+}
+tr.odd {
+	background-color: #e2e4ff
+}
+tr.even {
+	background-color: #fff
+}
+.dataTables_scroll {
+	clear: both
+}
+.bottom,
+.top {
+	padding: 15px;
+	background-color: #f5f5f5;
+	border: 1px solid #ccc
+}
+.top .dataTables_info {
+	float: none
+}
+.clear {
+	clear: both
+}
+.dataTables_empty {
+	text-align: center
+}
+tfoot input {
+	margin: .5em 0;
+	width: 100%;
+	color: #444
+}
+tfoot input.search_init {
+	color: #999
+}
+td.group {
+	background-color: #d1cfd0;
+	border-bottom: 2px solid #a19b9e;
+	border-top: 2px solid #a19b9e
+}
+td.details {
+	background-color: #d1cfd0;
+	border: 2px solid #a19b9e
+}
+.example_alt_pagination div.dataTables_info {
+	width: 40%
+}
+.paging_full_numbers span.paginate_active,
+.paging_full_numbers span.paginate_button {
+	border: 1px solid #aaa;
+	-webkit-border-radius: 5px;
+	-moz-border-radius: 5px;
+	padding: 2px 5px;
+	margin: 0 3px;
+	cursor: pointer
+}
+.paging_full_numbers span.paginate_button {
+	background-color: #ddd
+}
+.paging_full_numbers span.paginate_button:hover {
+	background-color: #ccc
+}
+.paging_full_numbers span.paginate_active {
+	background-color: #99b3ff
+}
+table.display tr.even.row_selected td {
+	background-color: #b0bed9
+}
+table.display tr.odd.row_selected td {
+	background-color: #9fafd1
+}
+tr.odd td.sorting_1 {
+	background-color: #d3d6ff
+}
+tr.odd td.sorting_2 {
+	background-color: #dadcff
+}
+tr.odd td.sorting_3 {
+	background-color: #e0e2ff
+}
+tr.even td.sorting_1 {
+	background-color: #eaebff
+}
+tr.even td.sorting_2 {
+	background-color: #f2f3ff
+}
+tr.even td.sorting_3 {
+	background-color: #f9f9ff
+}
+tr.odd.gradeA td.sorting_1 {
+	background-color: #f4f4f4
+}
+tr.odd.gradeA td.sorting_2 {
+	background-color: #d1ffd1
+}
+tr.odd.gradeA td.sorting_3 {
+	background-color: #d1ffd1
+}
+tr.even.gradeA td.sorting_1 {
+	background-color: #efefef
+}
+tr.even.gradeA td.sorting_2 {
+	background-color: #e2ffe2
+}
+tr.even.gradeA td.sorting_3 {
+	background-color: #e2ffe2
+}
+tr.odd.gradeC td.sorting_1 {
+	background-color: #c4c4ff
+}
+tr.odd.gradeC td.sorting_2 {
+	background-color: #d1d1ff
+}
+tr.odd.gradeC td.sorting_3 {
+	background-color: #d1d1ff
+}
+tr.even.gradeC td.sorting_1 {
+	background-color: #d5d5ff
+}
+tr.even.gradeC td.sorting_2 {
+	background-color: #e2e2ff
+}
+tr.even.gradeC td.sorting_3 {
+	background-color: #e2e2ff
+}
+tr.odd.gradeX td.sorting_1 {
+	background-color: #ffc4c4
+}
+tr.odd.gradeX td.sorting_2 {
+	background-color: #ffd1d1
+}
+tr.odd.gradeX td.sorting_3 {
+	background-color: #ffd1d1
+}
+tr.even.gradeX td.sorting_1 {
+	background-color: #ffd5d5
+}
+tr.even.gradeX td.sorting_2 {
+	background-color: #ffe2e2
+}
+tr.even.gradeX td.sorting_3 {
+	background-color: #ffe2e2
+}
+tr.odd.gradeU td.sorting_1 {
+	background-color: #c4c4c4
+}
+tr.odd.gradeU td.sorting_2 {
+	background-color: #d1d1d1
+}
+tr.odd.gradeU td.sorting_3 {
+	background-color: #d1d1d1
+}
+tr.even.gradeU td.sorting_1 {
+	background-color: #d5d5d5
+}
+tr.even.gradeU td.sorting_2 {
+	background-color: #e2e2e2
+}
+tr.even.gradeU td.sorting_3 {
+	background-color: #e2e2e2
+}
+#example tbody tr.even td.highlighted,
+.ex_highlight #example tbody tr.even:hover {
+	background-color: #ecffb3
+}
+#example tbody tr.odd td.highlighted,
+.ex_highlight #example tbody tr.odd:hover {
+	background-color: #e6ff99
+}
+.ui-helper-hidden {
+	display: none
+}
+.ui-helper-hidden-accessible {
+	position: absolute;
+	left: -99999999px
+}
+.ui-helper-reset {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	outline: 0;
+	line-height: 1.3;
+	text-decoration: none;
+	font-size: 100%;
+	list-style: none
+}
+.ui-helper-clearfix:after {
+	content: ".";
+	display: block;
+	height: 0;
+	clear: both;
+	visibility: hidden
+}
+.ui-helper-clearfix {
+	display: inline-block
+}
+* html .ui-helper-clearfix {
+	height: 1%
+}
+.ui-helper-clearfix {
+	display: block
+}
+.ui-helper-zfix {
+	width: 100%;
+	height: 100%;
+	top: 0;
+	left: 0;
+	position: absolute;
+	opacity: 0;
+	filter: Alpha(Opacity=0)
+}
+.ui-state-disabled {
+	cursor: default!important
+}
+.ui-icon {
+	display: block;
+	text-indent: -99999px;
+	overflow: hidden;
+	background-repeat: no-repeat
+}
+.ui-widget-overlay {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%
+}
+.ui-widget {
+	font-size: 12px
+}
+.ui-widget .ui-widget {
+	font-size: 1em
+}
+.ui-widget button,
+.ui-widget input,
+.ui-widget select,
+.ui-widget textarea {
+	font-family: Verdana, Arial, sans-serif;
+	font-size: 1em
+}
+.ui-widget-content a {
+	color: #222
+}
+.ui-widget-header {
+	font-weight: 700
+}
+.ui-widget-header a {
+	color: #222
+}
+.ui-state-default,
+.ui-widget-content .ui-state-default,
+.ui-widget-header .ui-state-default {
+	border-left: 1px solid #d5d5d5;
+	font-weight: 400;
+	border-bottom: 1px solid #d5d5d5
+}
+th.ui-state-default:first-child {
+	border-left: none
+}
+.ui-state-default a,
+.ui-state-default a:link,
+.ui-state-default a:visited {
+	color: #555;
+	text-decoration: none
+}
+.ui-state-focus,
+.ui-state-hover,
+.ui-widget-content .ui-state-focus,
+.ui-widget-content .ui-state-hover,
+.ui-widget-header .ui-state-focus,
+.ui-widget-header .ui-state-hover {
+	background: #fafafa;
+	font-weight: 400;
+	color: #212121
+}
+.ui-state-hover a,
+.ui-state-hover a:hover {
+	color: #797979;
+	text-decoration: none
+}
+.ui-state-active,
+.ui-widget-content .ui-state-active,
+.ui-widget-header .ui-state-active {
+	background: #fafafa;
+	font-weight: 400;
+	color: #797979
+}
+.ui-state-active a,
+.ui-state-active a:link,
+.ui-state-active a:visited {
+	color: #797979;
+	text-decoration: none
+}
+.ui-widget:active {
+	outline: 0
+}
+.ui-state-highlight a,
+.ui-widget-content .ui-state-highlight a,
+.ui-widget-header .ui-state-highlight a {
+	color: #363636
+}
+.ui-state-error,
+.ui-widget-content .ui-state-error,
+.ui-widget-header .ui-state-error {
+	border: 1px solid #cd0a0a;
+	background: #fef1ec url(../images/jquery_ui/ui-bg_glass_95_fef1ec_1x400.png) 50% 50% repeat-x;
+	color: #cd0a0a
+}
+.ui-state-error a,
+.ui-widget-content .ui-state-error a,
+.ui-widget-header .ui-state-error a {
+	color: #cd0a0a
+}
+.ui-state-error-text,
+.ui-widget-content .ui-state-error-text,
+.ui-widget-header .ui-state-error-text {
+	color: #cd0a0a
+}
+.ui-priority-primary,
+.ui-widget-content .ui-priority-primary,
+.ui-widget-header .ui-priority-primary {
+	font-weight: 700
+}
+.ui-priority-secondary,
+.ui-widget-content .ui-priority-secondary,
+.ui-widget-header .ui-priority-secondary {
+	opacity: .7;
+	filter: Alpha(Opacity=70);
+	font-weight: 400
+}
+.ui-state-disabled,
+.ui-widget-content .ui-state-disabled,
+.ui-widget-header .ui-state-disabled {
+	opacity: .35;
+	filter: Alpha(Opacity=35);
+	background-image: none
+}
+.ui-icon {
+	width: 16px;
+	height: 16px;
+	background-image: url(../images/jquery_ui/ui-icons_222222_256x240.png)
+}
+.ui-widget-content .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_222222_256x240.png)
+}
+.ui-widget-header .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_222222_256x240.png)
+}
+.ui-state-default .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_888888_256x240.png)
+}
+.ui-state-focus .ui-icon,
+.ui-state-hover .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_454545_256x240.png)
+}
+.ui-state-active .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_454545_256x240.png)
+}
+.ui-state-highlight .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_2e83ff_256x240.png)
+}
+.ui-state-error .ui-icon,
+.ui-state-error-text .ui-icon {
+	background-image: url(../images/jquery_ui/ui-icons_cd0a0a_256x240.png)
+}
+.ui-icon-carat-1-n {
+	background-position: 0 0
+}
+.ui-icon-carat-1-ne {
+	background-position: -16px 0
+}
+.ui-icon-carat-1-e {
+	background-position: -32px 0
+}
+.ui-icon-carat-1-se {
+	background-position: -48px 0
+}
+.ui-icon-carat-1-s {
+	background-position: -64px 0
+}
+.ui-icon-carat-1-sw {
+	background-position: -80px 0
+}
+.ui-icon-carat-1-w {
+	background-position: -96px 0
+}
+.ui-icon-carat-1-nw {
+	background-position: -112px 0
+}
+.ui-icon-carat-2-n-s {
+	background-position: -128px 0
+}
+.ui-icon-carat-2-e-w {
+	background-position: -144px 0
+}
+.ui-icon-triangle-1-n {
+	background-position: 0 -16px
+}
+.ui-icon-triangle-1-ne {
+	background-position: -16px -16px
+}
+.ui-icon-triangle-1-e {
+	background-position: -32px -16px
+}
+.ui-icon-triangle-1-se {
+	background-position: -48px -16px
+}
+.ui-icon-triangle-1-s {
+	background-position: -64px -16px
+}
+.ui-icon-triangle-1-sw {
+	background-position: -80px -16px
+}
+.ui-icon-triangle-1-w {
+	background-position: -96px -16px
+}
+.ui-icon-triangle-1-nw {
+	background-position: -112px -16px
+}
+.ui-icon-triangle-2-n-s {
+	background-position: -128px -16px
+}
+.ui-icon-triangle-2-e-w {
+	background-position: -144px -16px
+}
+.ui-icon-arrow-1-n {
+	background-position: 0 -32px
+}
+.ui-icon-arrow-1-ne {
+	background-position: -16px -32px
+}
+.ui-icon-arrow-1-e {
+	background-position: -32px -32px
+}
+.ui-icon-arrow-1-se {
+	background-position: -48px -32px
+}
+.ui-icon-arrow-1-s {
+	background-position: -64px -32px
+}
+.ui-icon-arrow-1-sw {
+	background-position: -80px -32px
+}
+.ui-icon-arrow-1-w {
+	background-position: -96px -32px
+}
+.ui-icon-arrow-1-nw {
+	background-position: -112px -32px
+}
+.ui-icon-arrow-2-n-s {
+	background-position: -128px -32px
+}
+.ui-icon-arrow-2-ne-sw {
+	background-position: -144px -32px
+}
+.ui-icon-arrow-2-e-w {
+	background-position: -160px -32px
+}
+.ui-icon-arrow-2-se-nw {
+	background-position: -176px -32px
+}
+.ui-icon-arrowstop-1-n {
+	background-position: -192px -32px
+}
+.ui-icon-arrowstop-1-e {
+	background-position: -208px -32px
+}
+.ui-icon-arrowstop-1-s {
+	background-position: -224px -32px
+}
+.ui-icon-arrowstop-1-w {
+	background-position: -240px -32px
+}
+.ui-icon-arrowthick-1-n {
+	background-position: 0 -48px
+}
+.ui-icon-arrowthick-1-ne {
+	background-position: -16px -48px
+}
+.ui-icon-arrowthick-1-e {
+	background-position: -32px -48px
+}
+.ui-icon-arrowthick-1-se {
+	background-position: -48px -48px
+}
+.ui-icon-arrowthick-1-s {
+	background-position: -64px -48px
+}
+.ui-icon-arrowthick-1-sw {
+	background-position: -80px -48px
+}
+.ui-icon-arrowthick-1-w {
+	background-position: -96px -48px
+}
+.ui-icon-arrowthick-1-nw {
+	background-position: -112px -48px
+}
+.ui-icon-arrowthick-2-n-s {
+	background-position: -128px -48px
+}
+.ui-icon-arrowthick-2-ne-sw {
+	background-position: -144px -48px
+}
+.ui-icon-arrowthick-2-e-w {
+	background-position: -160px -48px
+}
+.ui-icon-arrowthick-2-se-nw {
+	background-position: -176px -48px
+}
+.ui-icon-arrowthickstop-1-n {
+	background-position: -192px -48px
+}
+.ui-icon-arrowthickstop-1-e {
+	background-position: -208px -48px
+}
+.ui-icon-arrowthickstop-1-s {
+	background-position: -224px -48px
+}
+.ui-icon-arrowthickstop-1-w {
+	background-position: -240px -48px
+}
+.ui-icon-arrowreturnthick-1-w {
+	background-position: 0 -64px
+}
+.ui-icon-arrowreturnthick-1-n {
+	background-position: -16px -64px
+}
+.ui-icon-arrowreturnthick-1-e {
+	background-position: -32px -64px
+}
+.ui-icon-arrowreturnthick-1-s {
+	background-position: -48px -64px
+}
+.ui-icon-arrowreturn-1-w {
+	background-position: -64px -64px
+}
+.ui-icon-arrowreturn-1-n {
+	background-position: -80px -64px
+}
+.ui-icon-arrowreturn-1-e {
+	background-position: -96px -64px
+}
+.ui-icon-arrowreturn-1-s {
+	background-position: -112px -64px
+}
+.ui-icon-arrowrefresh-1-w {
+	background-position: -128px -64px
+}
+.ui-icon-arrowrefresh-1-n {
+	background-position: -144px -64px
+}
+.ui-icon-arrowrefresh-1-e {
+	background-position: -160px -64px
+}
+.ui-icon-arrowrefresh-1-s {
+	background-position: -176px -64px
+}
+.ui-icon-arrow-4 {
+	background-position: 0 -80px
+}
+.ui-icon-arrow-4-diag {
+	background-position: -16px -80px
+}
+.ui-icon-extlink {
+	background-position: -32px -80px
+}
+.ui-icon-newwin {
+	background-position: -48px -80px
+}
+.ui-icon-refresh {
+	background-position: -64px -80px
+}
+.ui-icon-shuffle {
+	background-position: -80px -80px
+}
+.ui-icon-transfer-e-w {
+	background-position: -96px -80px
+}
+.ui-icon-transferthick-e-w {
+	background-position: -112px -80px
+}
+.ui-icon-folder-collapsed {
+	background-position: 0 -96px
+}
+.ui-icon-folder-open {
+	background-position: -16px -96px
+}
+.ui-icon-document {
+	background-position: -32px -96px
+}
+.ui-icon-document-b {
+	background-position: -48px -96px
+}
+.ui-icon-note {
+	background-position: -64px -96px
+}
+.ui-icon-mail-closed {
+	background-position: -80px -96px
+}
+.ui-icon-mail-open {
+	background-position: -96px -96px
+}
+.ui-icon-suitcase {
+	background-position: -112px -96px
+}
+.ui-icon-comment {
+	background-position: -128px -96px
+}
+.ui-icon-person {
+	background-position: -144px -96px
+}
+.ui-icon-print {
+	background-position: -160px -96px
+}
+.ui-icon-trash {
+	background-position: -176px -96px
+}
+.ui-icon-locked {
+	background-position: -192px -96px
+}
+.ui-icon-unlocked {
+	background-position: -208px -96px
+}
+.ui-icon-bookmark {
+	background-position: -224px -96px
+}
+.ui-icon-tag {
+	background-position: -240px -96px
+}
+.ui-icon-home {
+	background-position: 0 -112px
+}
+.ui-icon-flag {
+	background-position: -16px -112px
+}
+.ui-icon-calendar {
+	background-position: -32px -112px
+}
+.ui-icon-cart {
+	background-position: -48px -112px
+}
+.ui-icon-pencil {
+	background-position: -64px -112px
+}
+.ui-icon-clock {
+	background-position: -80px -112px
+}
+.ui-icon-disk {
+	background-position: -96px -112px
+}
+.ui-icon-calculator {
+	background-position: -112px -112px
+}
+.ui-icon-zoomin {
+	background-position: -128px -112px
+}
+.ui-icon-zoomout {
+	background-position: -144px -112px
+}
+.ui-icon-search {
+	background-position: -160px -112px
+}
+.ui-icon-wrench {
+	background-position: -176px -112px
+}
+.ui-icon-gear {
+	background-position: -192px -112px
+}
+.ui-icon-heart {
+	background-position: -208px -112px
+}
+.ui-icon-star {
+	background-position: -224px -112px
+}
+.ui-icon-link {
+	background-position: -240px -112px
+}
+.ui-icon-cancel {
+	background-position: 0 -128px
+}
+.ui-icon-plus {
+	background-position: -16px -128px
+}
+.ui-icon-plusthick {
+	background-position: -32px -128px
+}
+.ui-icon-minus {
+	background-position: -48px -128px
+}
+.ui-icon-minusthick {
+	background-position: -64px -128px
+}
+.ui-icon-close {
+	background-position: -80px -128px
+}
+.ui-icon-closethick {
+	background-position: -96px -128px
+}
+.ui-icon-key {
+	background-position: -112px -128px
+}
+.ui-icon-lightbulb {
+	background-position: -128px -128px
+}
+.ui-icon-scissors {
+	background-position: -144px -128px
+}
+.ui-icon-clipboard {
+	background-position: -160px -128px
+}
+.ui-icon-copy {
+	background-position: -176px -128px
+}
+.ui-icon-contact {
+	background-position: -192px -128px
+}
+.ui-icon-image {
+	background-position: -208px -128px
+}
+.ui-icon-video {
+	background-position: -224px -128px
+}
+.ui-icon-script {
+	background-position: -240px -128px
+}
+.ui-icon-alert {
+	background-position: 0 -144px
+}
+.ui-icon-info {
+	background-position: -16px -144px
+}
+.ui-icon-notice {
+	background-position: -32px -144px
+}
+.ui-icon-help {
+	background-position: -48px -144px
+}
+.ui-icon-check {
+	background-position: -64px -144px
+}
+.ui-icon-bullet {
+	background-position: -80px -144px
+}
+.ui-icon-radio-off {
+	background-position: -96px -144px
+}
+.ui-icon-radio-on {
+	background-position: -112px -144px
+}
+.ui-icon-pin-w {
+	background-position: -128px -144px
+}
+.ui-icon-pin-s {
+	background-position: -144px -144px
+}
+.ui-icon-play {
+	background-position: 0 -160px
+}
+.ui-icon-pause {
+	background-position: -16px -160px
+}
+.ui-icon-seek-next {
+	background-position: -32px -160px
+}
+.ui-icon-seek-prev {
+	background-position: -48px -160px
+}
+.ui-icon-seek-end {
+	background-position: -64px -160px
+}
+.ui-icon-seek-start {
+	background-position: -80px -160px
+}
+.ui-icon-seek-first {
+	background-position: -80px -160px
+}
+.ui-icon-stop {
+	background-position: -96px -160px
+}
+.ui-icon-eject {
+	background-position: -112px -160px
+}
+.ui-icon-volume-off {
+	background-position: -128px -160px
+}
+.ui-icon-volume-on {
+	background-position: -144px -160px
+}
+.ui-icon-power {
+	background-position: 0 -176px
+}
+.ui-icon-signal-diag {
+	background-position: -16px -176px
+}
+.ui-icon-signal {
+	background-position: -32px -176px
+}
+.ui-icon-battery-0 {
+	background-position: -48px -176px
+}
+.ui-icon-battery-1 {
+	background-position: -64px -176px
+}
+.ui-icon-battery-2 {
+	background-position: -80px -176px
+}
+.ui-icon-battery-3 {
+	background-position: -96px -176px
+}
+.ui-icon-circle-plus {
+	background-position: 0 -192px
+}
+.ui-icon-circle-minus {
+	background-position: -16px -192px
+}
+.ui-icon-circle-close {
+	background-position: -32px -192px
+}
+.ui-icon-circle-triangle-e {
+	background-position: -48px -192px
+}
+.ui-icon-circle-triangle-s {
+	background-position: -64px -192px
+}
+.ui-icon-circle-triangle-w {
+	background-position: -80px -192px
+}
+.ui-icon-circle-triangle-n {
+	background-position: -96px -192px
+}
+.ui-icon-circle-arrow-e {
+	background-position: -112px -192px
+}
+.ui-icon-circle-arrow-s {
+	background-position: -128px -192px
+}
+.ui-icon-circle-arrow-w {
+	background-position: -144px -192px
+}
+.ui-icon-circle-arrow-n {
+	background-position: -160px -192px
+}
+.ui-icon-circle-zoomin {
+	background-position: -176px -192px
+}
+.ui-icon-circle-zoomout {
+	background-position: -192px -192px
+}
+.ui-icon-circle-check {
+	background-position: -208px -192px
+}
+.ui-icon-circlesmall-plus {
+	background-position: 0 -208px
+}
+.ui-icon-circlesmall-minus {
+	background-position: -16px -208px
+}
+.ui-icon-circlesmall-close {
+	background-position: -32px -208px
+}
+.ui-icon-squaresmall-plus {
+	background-position: -48px -208px
+}
+.ui-icon-squaresmall-minus {
+	background-position: -64px -208px
+}
+.ui-icon-squaresmall-close {
+	background-position: -80px -208px
+}
+.ui-icon-grip-dotted-vertical {
+	background-position: 0 -224px
+}
+.ui-icon-grip-dotted-horizontal {
+	background-position: -16px -224px
+}
+.ui-icon-grip-solid-vertical {
+	background-position: -32px -224px
+}
+.ui-icon-grip-solid-horizontal {
+	background-position: -48px -224px
+}
+.ui-icon-gripsmall-diagonal-se {
+	background-position: -64px -224px
+}
+.ui-icon-grip-diagonal-se {
+	background-position: -80px -224px
+}
+.ui-corner-tl {
+	-moz-border-radius-topleft: 2px;
+	-webkit-border-top-left-radius: 2px;
+	border-top-left-radius: 2px
+}
+.ui-corner-tr {
+	-moz-border-radius-topright: 2px;
+	-webkit-border-top-right-radius: 2px;
+	border-top-right-radius: 2px
+}
+.ui-corner-bl {
+	-moz-border-radius-bottomleft: 2px;
+	-webkit-border-bottom-left-radius: 2px;
+	border-bottom-left-radius: 2px
+}
+.ui-corner-br {
+	-moz-border-radius-bottomright: 2px;
+	-webkit-border-bottom-right-radius: 2px;
+	border-bottom-right-radius: 2px
+}
+.ui-corner-top {
+	-moz-border-radius-topleft: 2px;
+	-webkit-border-top-left-radius: 2px;
+	border-top-left-radius: 2px;
+	-moz-border-radius-topright: 2px;
+	-webkit-border-top-right-radius: 2px;
+	border-top-right-radius: 2px
+}
+.ui-corner-bottom {
+	-moz-border-radius-bottomleft: 2px;
+	-webkit-border-bottom-left-radius: 2px;
+	border-bottom-left-radius: 2px;
+	-moz-border-radius-bottomright: 2px;
+	-webkit-border-bottom-right-radius: 2px;
+	border-bottom-right-radius: 2px
+}
+.ui-corner-right {
+	-moz-border-radius-topright: 2px;
+	-webkit-border-top-right-radius: 2px;
+	border-top-right-radius: 2px;
+	-moz-border-radius-bottomright: 2px;
+	-webkit-border-bottom-right-radius: 2px;
+	border-bottom-right-radius: 2px
+}
+.ui-corner-left {
+	-moz-border-radius-topleft: 2px;
+	-webkit-border-top-left-radius: 2px;
+	border-top-left-radius: 2px;
+	-moz-border-radius-bottomleft: 2px;
+	-webkit-border-bottom-left-radius: 2px;
+	border-bottom-left-radius: 2px
+}
+.ui-corner-all {
+	-moz-border-radius: 2px;
+	-webkit-border-radius: 2px;
+	border-radius: 2px
+}
+.ui-widget-overlay {
+	background: #aaa url(../images/jquery_ui/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x;
+	opacity: .3;
+	filter: Alpha(Opacity=30)
+}
+.ui-widget-shadow {
+	margin: -8px 0 0 -8px;
+	padding: 8px;
+	background: #aaa url(../images/jquery_ui/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x;
+	opacity: .3;
+	filter: Alpha(Opacity=30);
+	-moz-border-radius: 8px;
+	-webkit-border-radius: 8px;
+	border-radius: 8px
+}
+.ui-resizable {
+	position: relative
+}
+.ui-resizable-handle {
+	position: absolute;
+	font-size: .1px;
+	z-index: 99999;
+	display: block
+}
+.ui-resizable-autohide .ui-resizable-handle,
+.ui-resizable-disabled .ui-resizable-handle {
+	display: none
+}
+.ui-resizable-n {
+	cursor: n-resize;
+	height: 7px;
+	width: 100%;
+	top: -5px;
+	left: 0
+}
+.ui-resizable-s {
+	cursor: s-resize;
+	height: 7px;
+	width: 100%;
+	bottom: -5px;
+	left: 0
+}
+.ui-resizable-e {
+	cursor: e-resize;
+	width: 7px;
+	right: -5px;
+	top: 0;
+	height: 100%
+}
+.ui-resizable-w {
+	cursor: w-resize;
+	width: 7px;
+	left: -5px;
+	top: 0;
+	height: 100%
+}
+.ui-resizable-se {
+	cursor: se-resize;
+	width: 12px;
+	height: 12px;
+	right: 1px;
+	bottom: 1px
+}
+.ui-resizable-sw {
+	cursor: sw-resize;
+	width: 9px;
+	height: 9px;
+	left: -5px;
+	bottom: -5px
+}
+.ui-resizable-nw {
+	cursor: nw-resize;
+	width: 9px;
+	height: 9px;
+	left: -5px;
+	top: -5px
+}
+.ui-resizable-ne {
+	cursor: ne-resize;
+	width: 9px;
+	height: 9px;
+	right: -5px;
+	top: -5px
+}
+.ui-selectable-helper {
+	position: absolute;
+	z-index: 100;
+	border: 1px dotted #000
+}
+.ui-accordion {
+	width: 100%
+}
+.ui-accordion .ui-accordion-header {
+	cursor: pointer;
+	position: relative;
+	margin-top: 1px;
+	zoom: 1
+}
+.ui-accordion .ui-accordion-li-fix {
+	display: inline
+}
+.ui-accordion .ui-accordion-header-active {
+	border-bottom: 0!important
+}
+.ui-accordion .ui-accordion-header a {
+	display: block;
+	font-size: 1em;
+	padding: .5em .5em .5em .7em
+}
+.ui-accordion-icons .ui-accordion-header a {
+	padding-left: 2.2em
+}
+.ui-accordion .ui-accordion-header .ui-icon {
+	position: absolute;
+	left: .5em;
+	top: 50%;
+	margin-top: -8px
+}
+.ui-accordion .ui-accordion-content {
+	padding: 1em 2.2em;
+	border-top: 0;
+	margin-top: -2px;
+	position: relative;
+	top: 1px;
+	margin-bottom: 2px;
+	overflow: auto;
+	display: none;
+	zoom: 1
+}
+.ui-accordion .ui-accordion-content-active {
+	display: block
+}
+.ui-autocomplete {
+	position: absolute;
+	cursor: default
+}
+* html .ui-autocomplete {
+	width: 1px
+}
+.ui-menu {
+	list-style: none;
+	padding: 2px;
+	margin: 0;
+	display: block;
+	float: left
+}
+.ui-menu .ui-menu {
+	margin-top: -3px
+}
+.ui-menu .ui-menu-item {
+	margin: 0;
+	padding: 0;
+	zoom: 1;
+	float: left;
+	clear: left;
+	width: 100%
+}
+.ui-menu .ui-menu-item a {
+	text-decoration: none;
+	display: block;
+	padding: .2em .4em;
+	line-height: 1.5;
+	zoom: 1
+}
+.ui-menu .ui-menu-item a.ui-state-active,
+.ui-menu .ui-menu-item a.ui-state-hover {
+	font-weight: 400;
+	margin: -1px
+}
+.ui-button {
+	display: inline-block;
+	position: relative;
+	padding: 0;
+	margin-right: .1em;
+	text-decoration: none!important;
+	cursor: pointer;
+	text-align: center;
+	zoom: 1;
+	overflow: visible
+}
+.ui-button-icon-only {
+	width: 2.2em
+}
+button.ui-button-icon-only {
+	width: 2.4em
+}
+.ui-button-icons-only {
+	width: 3.4em
+}
+button.ui-button-icons-only {
+	width: 3.7em
+}
+.ui-button .ui-button-text {
+	display: block;
+	line-height: 1.4
+}
+.ui-button-icon-only .ui-button-text,
+.ui-button-icons-only .ui-button-text {
+	padding: .4em;
+	text-indent: -9999999px
+}
+.ui-button-text-icon-primary .ui-button-text,
+.ui-button-text-icons .ui-button-text {
+	padding: .4em 1em .4em 2.1em
+}
+.ui-button-text-icon-secondary .ui-button-text,
+.ui-button-text-icons .ui-button-text {
+	padding: .4em 2.1em .4em 1em
+}
+.ui-button-text-icons .ui-button-text {
+	padding-left: 2.1em;
+	padding-right: 2.1em
+}
+input.ui-button {
+	padding: .4em 1em
+}
+.ui-button-icon-only .ui-icon,
+.ui-button-icons-only .ui-icon,
+.ui-button-text-icon-primary .ui-icon,
+.ui-button-text-icon-secondary .ui-icon,
+.ui-button-text-icons .ui-icon {
+	position: absolute;
+	top: 50%;
+	margin-top: -8px
+}
+.ui-button-icon-only .ui-icon {
+	left: 50%;
+	margin-left: -8px
+}
+.ui-button-icons-only .ui-button-icon-primary,
+.ui-button-text-icon-primary .ui-button-icon-primary,
+.ui-button-text-icons .ui-button-icon-primary {
+	left: .5em
+}
+.ui-button-icons-only .ui-button-icon-secondary,
+.ui-button-text-icon-secondary .ui-button-icon-secondary,
+.ui-button-text-icons .ui-button-icon-secondary {
+	right: .5em
+}
+.ui-button-icons-only .ui-button-icon-secondary,
+.ui-button-text-icons .ui-button-icon-secondary {
+	right: .5em
+}
+.ui-buttonset {
+	margin-right: 5px
+}
+.ui-buttonset .ui-button {
+	margin: 0 3px;
+	background: #fafafa;
+	border: 1px solid #d5d5d5;
+	line-height: 14px;
+	font-size: 11px
+}
+button.ui-button::-moz-focus-inner {
+	border: 0;
+	padding: 0
+}
+.ui-dialog {
+	position: absolute;
+	padding: .2em;
+	width: 300px;
+	overflow: hidden
+}
+.ui-dialog .ui-dialog-titlebar {
+	position: relative
+}
+.ui-dialog .ui-dialog-title {
+	float: left;
+	height: 38px;
+	font-size: 16px;
+	padding: 0 12px 0 12px;
+	line-height: 38px
+}
+.ui-dialog .ui-dialog-titlebar-close {
+	position: absolute;
+	right: 6px;
+	top: 50%;
+	width: 19px;
+	margin: -10px 0 0 0;
+	padding: 1px;
+	height: 18px
+}
+.ui-dialog .ui-dialog-titlebar-close span {
+	display: block;
+	margin: 1px
+}
+.ui-dialog .ui-dialog-titlebar-close:focus,
+.ui-dialog .ui-dialog-titlebar-close:hover {
+	padding: 1px;
+	background: #fafafa
+}
+.ui-dialog .ui-dialog-content {
+	position: relative;
+	border: 0;
+	padding: .5em 1em;
+	background: 0 0;
+	overflow: auto;
+	zoom: 1
+}
+.ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset {
+	float: right
+}
+.ui-dialog .ui-dialog-buttonpane button {
+	font-size: 10px;
+	font-weight: 700;
+	text-transform: uppercase;
+	padding: 3px 12px 4px 12px;
+	cursor: pointer;
+	font-family: Arial, Helvetica, sans-serif;
+	border: 1px solid #d5d5d5;
+	color: #525252;
+	margin: 5px
+}
+.ui-dialog .ui-resizable-se {
+	width: 14px;
+	height: 14px;
+	right: 3px;
+	bottom: 3px
+}
+.ui-draggable .ui-dialog-titlebar {
+	cursor: move
+}
+.ui-slider {
+	position: relative;
+	text-align: left
+}
+.ui-slider .ui-slider-handle {
+	position: absolute;
+	z-index: 2;
+	width: 16px;
+	height: 16px;
+	cursor: default;
+	background: url(../images/ui/handle.png) no-repeat;
+	border: none;
+	cursor: pointer
+}
+.ui-slider .ui-slider-range {
+	position: absolute;
+	z-index: 1;
+	font-size: .7em;
+	display: block;
+	border: 0;
+	background: url(../images/ui/sliderOverlay.png) repeat-x;
+	-moz-border-radius: 4px;
+	-webkit-border-radius: 4px;
+	-khtml-border-radius: 4px;
+	border-radius: 4px
+}
+.ui-slider-horizontal {
+	height: 6px;
+	background: url(../images/ui/sliderBg.png) repeat-x;
+	clear: both;
+	margin-top: 10px
+}
+.ui-slider-horizontal .ui-slider-handle {
+	top: -5px;
+	margin-left: -.6em
+}
+.ui-slider-horizontal .ui-slider-range {
+	top: 0;
+	height: 100%
+}
+.ui-slider-horizontal .ui-slider-range-min {
+	left: 0
+}
+.ui-slider-horizontal .ui-slider-range-max {
+	right: 0
+}
+.ui-slider-vertical {
+	width: 6px;
+	height: 100px;
+	background: url(../images/ui/sliderBgVert.png) repeat-y
+}
+.ui-slider-vertical .ui-slider-handle {
+	left: -5px;
+	margin-left: 0;
+	margin-bottom: -.6em
+}
+.ui-slider-vertical .ui-slider-range {
+	left: 0;
+	width: 100%;
+	background: url(../images/ui/sliderOverlayVert.png) repeat-y
+}
+.ui-slider-vertical .ui-slider-range-min {
+	bottom: 0
+}
+.ui-slider-vertical .ui-slider-range-max {
+	top: 0
+}
+.ui-tabs {
+	position: relative;
+	padding: .2em;
+	zoom: 1
+}
+.ui-tabs .ui-tabs-nav {
+	margin: 0;
+	padding: .2em .2em 0
+}
+.ui-tabs .ui-tabs-nav li {
+	list-style: none;
+	float: left;
+	position: relative;
+	top: 1px;
+	margin: 0 .2em 1px 0;
+	border-bottom: 0!important;
+	padding: 0;
+	white-space: nowrap
+}
+.ui-tabs .ui-tabs-nav li a {
+	float: left;
+	padding: .5em 1em;
+	text-decoration: none
+}
+.ui-tabs .ui-tabs-nav li.ui-tabs-selected {
+	margin-bottom: 0;
+	padding-bottom: 1px
+}
+.ui-tabs .ui-tabs-nav li.ui-state-disabled a,
+.ui-tabs .ui-tabs-nav li.ui-state-processing a,
+.ui-tabs .ui-tabs-nav li.ui-tabs-selected a {
+	cursor: text
+}
+.ui-tabs .ui-tabs-nav li a,
+.ui-tabs.ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-selected a {
+	cursor: pointer
+}
+.ui-tabs .ui-tabs-panel {
+	display: block;
+	border-width: 0;
+	padding: 1em 1.4em;
+	background: 0 0
+}
+.ui-tabs .ui-tabs-hide {
+	display: none!important
+}
+.datepicker {
+	width: 58px!important
+}
+.ui-datepicker {
+	width: 17em;
+	padding: .2em .2em 0;
+	border: 1px solid #d5d5d5;
+	background: #fafafa;
+	margin-top: 1px;
+	z-index: 3;
+	display: none
+}
+.ui-datepicker-append {
+	margin-left: 10px
+}
+.ui-datepicker .ui-datepicker-header {
+	position: relative;
+	padding: .2em 0;
+	border: 1px solid #e7e7e7;
+	background: url(../images/leftNavBg.png) repeat-x
+}
+.ui-datepicker .ui-datepicker-next,
+.ui-datepicker .ui-datepicker-prev {
+	position: absolute;
+	top: 2px;
+	width: 1.8em;
+	height: 1.8em
+}
+.ui-datepicker .ui-datepicker-next-hover,
+.ui-datepicker .ui-datepicker-prev-hover {
+	top: 1px
+}
+.ui-datepicker .ui-datepicker-prev {
+	left: 2px
+}
+.ui-datepicker .ui-datepicker-next {
+	right: 2px
+}
+.ui-datepicker .ui-datepicker-prev-hover {
+	left: 1px
+}
+.ui-datepicker .ui-datepicker-next-hover {
+	right: 1px
+}
+.ui-datepicker .ui-datepicker-next span,
+.ui-datepicker .ui-datepicker-prev span {
+	display: block;
+	position: absolute;
+	left: 50%;
+	margin-left: -8px;
+	top: 50%;
+	margin-top: -8px
+}
+.ui-datepicker .ui-datepicker-title {
+	margin: 0 2.3em;
+	line-height: 1.8em;
+	text-align: center
+}
+.ui-datepicker .ui-datepicker-title select {
+	font-size: 1em;
+	margin: 1px 0
+}
+.ui-datepicker select.ui-datepicker-month-year {
+	width: 100%
+}
+.ui-datepicker select.ui-datepicker-month,
+.ui-datepicker select.ui-datepicker-year {
+	width: 49%
+}
+.ui-datepicker table {
+	width: 100%;
+	font-size: .9em;
+	border-collapse: collapse;
+	margin: 0 0 .4em
+}
+.ui-datepicker table .ui-state-default {
+	border: 1px solid #d5d5d5
+}
+.ui-datepicker table tbody {
+	font-size: 11px
+}
+.ui-datepicker th {
+	padding: .7em .3em;
+	text-align: center;
+	font-weight: 700;
+	border: 0
+}
+.ui-datepicker td {
+	border: 0;
+	padding: 1px
+}
+.ui-datepicker td a,
+.ui-datepicker td span {
+	display: block;
+	padding: .2em;
+	text-align: right;
+	text-decoration: none
+}
+.ui-datepicker .ui-datepicker-buttonpane {
+	background-image: none;
+	margin: .7em 0 0 0;
+	padding: 0 .2em;
+	border-left: 0;
+	border-right: 0;
+	border-bottom: 0
+}
+.ui-datepicker .ui-datepicker-buttonpane button {
+	float: right;
+	margin: .5em .2em .4em;
+	cursor: pointer;
+	padding: .2em .6em .3em .6em;
+	width: auto;
+	overflow: visible
+}
+.ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current {
+	float: left
+}
+.ui-datepicker.ui-datepicker-multi {
+	width: auto
+}
+.ui-datepicker-multi .ui-datepicker-group {
+	float: left
+}
+.ui-datepicker-multi .ui-datepicker-group table {
+	width: 95%;
+	margin: 0 auto .4em
+}
+.ui-datepicker-multi-2 .ui-datepicker-group {
+	width: 50%
+}
+.ui-datepicker-multi-3 .ui-datepicker-group {
+	width: 33.3%
+}
+.ui-datepicker-multi-4 .ui-datepicker-group {
+	width: 25%
+}
+.ui-datepicker-multi .ui-datepicker-group-last .ui-datepicker-header {
+	border-left-width: 0
+}
+.ui-datepicker-multi .ui-datepicker-group-middle .ui-datepicker-header {
+	border-left-width: 0
+}
+.ui-datepicker-multi .ui-datepicker-buttonpane {
+	clear: left
+}
+.ui-datepicker-row-break {
+	clear: both;
+	width: 100%
+}
+.ui-datepicker-rtl {
+	direction: rtl
+}
+.ui-datepicker-rtl .ui-datepicker-prev {
+	right: 2px;
+	left: auto
+}
+.ui-datepicker-rtl .ui-datepicker-next {
+	left: 2px;
+	right: auto
+}
+.ui-datepicker-rtl .ui-datepicker-prev:hover {
+	right: 1px;
+	left: auto
+}
+.ui-datepicker-rtl .ui-datepicker-next:hover {
+	left: 1px;
+	right: auto
+}
+.ui-datepicker-rtl .ui-datepicker-buttonpane {
+	clear: right
+}
+.ui-datepicker-rtl .ui-datepicker-buttonpane button {
+	float: left
+}
+.ui-datepicker-rtl .ui-datepicker-buttonpane button.ui-datepicker-current {
+	float: right
+}
+.ui-datepicker-rtl .ui-datepicker-group {
+	float: right
+}
+.ui-datepicker-rtl .ui-datepicker-group-last .ui-datepicker-header {
+	border-right-width: 0;
+	border-left-width: 1px
+}
+.ui-datepicker-rtl .ui-datepicker-group-middle .ui-datepicker-header {
+	border-right-width: 0;
+	border-left-width: 1px
+}
+.ui-progressbar {
+	height: 16px;
+	text-align: left;
+	margin-top: 5px;
+	background: url(../images/ui/progress.png) repeat-x
+}
+.ui-progressbar .ui-progressbar-value {
+	margin: 0;
+	height: 100%;
+	overflow: hidden;
+	display: block;
+	background: url(../images/ui/progressOverlay.png) repeat-x;
+	border-right: 1px solid #3c95d8
+}
+.pbar .ui-progressbar-value {
+	display: block!important
+}
+.pbar {
+	overflow: hidden;
+	background: url(../images/ui/progress.png) repeat-x
+}
+.percent {
+	position: relative;
+	text-align: right;
+	margin-bottom: 5px;
+	font-size: 11px
+}
+.elapsed {
+	position: relative;
+	text-align: right;
+	margin-top: 5px;
+	font-size: 11px
+}
+html {
+	height: 100%
+}
+* html body {
+	height: 100%
+}
+body {
+	margin: 0;
+	padding: 0;
+	background: #f5f5f5;
+	font-size: 12px;
+	color: #424242;
+	font-family: Arial, Helvetica, sans-serif;
+	line-height: 20px;
+	min-height: 100%;
+	position: relative
+}
+label.error {
+	color: #a73939;
+	font-size: 11px;
+	display: block;
+	width: 100%;
+	white-space: nowrap;
+	float: none;
+	margin: 8px 0 -8px 0;
+	padding: 0!important
+}
+.selector .error {
+	margin-right: -220px;
+	float: right
+}
+.checker label.error,
+.radio label.error {
+	display: inline;
+	margin: 0
+}
+.req {
+	margin-left: 5px;
+	color: #db6464
+}
+.formNote {
+	display: block;
+	text-align: left;
+	font-size: 11px;
+	padding-top: 5px;
+	color: #939393
+}
+div.tagsinput {
+	border: 1px solid #ddd;
+	background: #fff;
+	padding: 5px;
+	width: 100%;
+	overflow-y: auto;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-ms-box-sizing: border-box;
+	box-sizing: border-box
+}
+div.tagsinput span.tag {
+	border: 1px solid #a5d24a;
+	display: block;
+	float: left;
+	padding: 3px 8px 2px 8px;
+	background: #cde69c;
+	color: #638421;
+	margin: 5px 5px 5px 5px
+}
+div.tagsinput span.tag a {
+	font-weight: 700;
+	color: #82ad2b;
+	font-size: 11px;
+	float: right;
+	margin-top: -1px
+}
+div.tagsinput input {
+	width: 80px;
+	border: none;
+	padding: 5px;
+	background: 0 0;
+	margin: 5px 5px 0 0
+}
+div.tagsinput div {
+	display: block;
+	float: left
+}
+.tags_clear {
+	clear: both;
+	width: 100%;
+	height: 0
+}
+.not_valid {
+	background: #fbd8db!important;
+	color: #90111a!important
+}
+.limiterBox {
+	border: 1px solid #ddd;
+	border-top: none;
+	background: #efefef url(../images/leftNavBg.png) repeat-x;
+	padding: 4px 6px;
+	font-size: 11px;
+	margin-top: 1px
+}
+::-webkit-input-placeholder {
+	color: #b3b3b3
+}
+:-moz-placeholder {
+	color: #b3b3b3
+}
+.corner {
+	-webkit-border-bottom-left-radius: 0!important;
+	-webkit-border-bottom-right-radius: 0!important;
+	-moz-border-radius-bottomleft: 0!important;
+	-moz-border-radius-bottomright: 0!important
+}
+.wrapper {
+	margin: 0 10%;
+	clear: both;
+    padding-top: 5px;
+}
+.img {
+	border: 1px solid #d5d5d5
+}
+.errorPage p,
+.leftNav ul li a,
+.stats ul li span,
+.ui-dialog .ui-dialog-title,
+.userLink,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+ul.tabs li a {
+	font-family: Cuprum, sans-serif;
+	font-weight: 400
+}
+h1 {
+	font-size: 24px
+}
+h2 {
+	font-size: 22px
+}
+h3 {
+	font-size: 20px
+}
+h4 {
+	font-size: 18px
+}
+h5 {
+	font-size: 16px
+}
+h6 {
+	font-size: 14px
+}
+blockquote {
+	border: 1px solid #d5d5d5;
+	margin-top: 40px;
+	padding: 15px 10px;
+	quotes: "\201C""\201D";
+	background: #fafafa;
+	text-align: center;
+	font-style: italic;
+	font-size: 12px;
+	border-left: 4px solid #d5d5d5
+}
+blockquote:before {
+	content: open-quote;
+	font-weight: 700
+}
+blockquote:after {
+	content: close-quote;
+	font-weight: 700
+}
+.red {
+	color: #b55d5c
+}
+.green {
+	color: #2a8827
+}
+p {
+	padding: 12px 0 0 0
+}
+.p12 {
+	padding: 12px
+}
+.pt12 {
+	padding-top: 12px
+}
+.legendLabel span {
+	display: block;
+	margin: 0 5px
+}
+.legendColorBox {
+	padding-left: 10px
+}
+.mt40 {
+	margin-top: 40px
+}
+.nomargin {
+	margin: 0!important
+}
+.nopadding {
+	padding: 0!important
+}
+.noborder {
+	border: none!important
+}
+.nobg {
+	background: 0 0!important
+}
+.floatleft {
+	display: block;
+	float: left
+}
+.floatright {
+	display: block;
+	float: right
+}
+.aligncenter {
+	text-align: center
+}
+.fix {
+	clear: both
+}
+.first {
+	margin-top: 25px!important
+}
+.inactive {
+	margin-top: 0;
+	color: #2b6893
+}
+.displayNone {
+	display: none
+}
+.wide {
+	width: 100%
+}
+.currency {
+	text-align: right;
+	font-weight: 700
+}
+.ml122 {
+	margin-left: 122px
+}
+.w40 {
+	width: 40%;
+	position: relative
+}
+.loginPanel {
+	width: 320px;
+	background: #fafafa;
+	border: 1px solid #d5d5d5;
+	border-top: 0;
+	display: block;
+	height: 212px
+}
+.loginWrapper {
+    position: absolute;
+    top: 25%;
+    left: 50%;
+    transform: translateX(-50%);
+}
+.loginLogo {
+    text-align: center;
+    margin: 0 0 20px;
+}
+.loginPanel h5 {
+	font-weight: 400;
+	padding: 9px 12px 9px 35px;
+	float: left
+}
+.loginPanel label {
+	width: 60px
+}
+.rememberMe {
+	margin-left: 12px
+}
+.rememberMe label {
+	padding: 4px 12px!important;
+	width: auto
+}
+.loginInput {
+	width: 200px;
+	float: left
+}
+.loginRow {
+	border-top: 1px solid #e7e7e7;
+	padding: 15px 0;
+	position: relative
+}
+.loginRow:first-child {
+	border-top: none
+}
+.backTo a:hover {
+	background: #212121
+}
+.backTo span {
+	padding: 8px 14px 8px 8px;
+	display: block;
+	float: left
+}
+.backTo img {
+	margin: 13px 2px 11px 14px;
+	float: left;
+	display: block
+}
+.backTo a {
+	float: left;
+	color: #eee;
+	font-size: 11px;
+	border-right: 1px solid #2f2f2f;
+	border-left: 1px solid #2f2f2f
+}
+.button,
+button,
+input[type=button],
+input[type=reset],
+input[type=submit] {
+	font-size: 10px;
+	font-weight: 700;
+	text-transform: uppercase;
+	padding: 5px 14px 6px 14px;
+	cursor: pointer;
+	font-family: Arial, Helvetica, sans-serif;
+	line-height: 12px
+}
+.basicBtn {
+	background: url(../images/ui/basicBtn.png) repeat-x 0 0;
+	border: 1px solid #d5d5d5;
+	color: #525252
+}
+.basicBtn:hover {
+	background-position: 0 -25px;
+	border-color: #c9c9c9
+}
+.basicBtn:active {
+	background-position: 0 -50px
+}
+.blueBtn {
+	background: url(../images/ui/blueBtn.png) repeat-x 0 0;
+	border: 1px solid #3581c1;
+	color: #fff
+}
+.blueBtn:hover {
+	background-position: 0 -25px
+}
+.blueBtn:active {
+	background-position: 0 -50px
+}
+.redBtn {
+	background: url(../images/ui/redBtn.png) repeat-x 0 0;
+	border: 1px solid #9d342a;
+	color: #fff
+}
+.redBtn:hover {
+	background-position: 0 -25px
+}
+.redBtn:active {
+	background-position: 0 -50px
+}
+.seaBtn {
+	background: url(../images/ui/seaBtn.png) repeat-x 0 0;
+	border: 1px solid #306873;
+	color: #fff
+}
+.seaBtn:hover {
+	background-position: 0 -25px
+}
+.seaBtn:active {
+	background-position: 0 -50px
+}
+.blackBtn {
+	background: url(../images/ui/blackBtn.png) repeat-x 0 0;
+	border: 1px solid #353535;
+	color: #fff
+}
+.blackBtn:hover {
+	background-position: 0 -25px
+}
+.blackBtn:active {
+	background-position: 0 -50px
+}
+.greyishBtn {
+    border: 1px solid #2b5783;
+    box-shadow: inset 0em -0.2em 0 0px #2a5784;
+    color: #2a5784;
+    border-radius: 3px;
+    background: #fff;
+}
+.greyishBtn:hover {
+	background-position: 0 -25px;
+	background-color: #f6f9ff;
+}
+.greyishBtn:focus {
+	background-position: 0 -25px;
+	background-color: #f6f9ff;
+    box-shadow: inset 0em -0.2em 0 0px #2a5784;
+    transform: translateY(1px);
+}
+.greyishBtn:active {
+	background-position: 0 -50px
+}
+.greenBtn {
+	background: url(../images/ui/greenBtn.png) repeat-x 0 0;
+	border: 1px solid #418d4f;
+	color: #fff
+}
+.greenBtn:hover {
+	background-position: 0 -25px
+}
+.greenBtn:active {
+	background-position: 0 -50px
+}
+.btn14 {
+	border: 1px solid #d5d5d5;
+	background: url(../images/leftNavBg.png) repeat-x 0 0;
+	padding: 6px 8px;
+	display: inline-block
+}
+.btn14:hover {
+	background: #f6f6f6
+}
+.btn14:active {
+	background: #f1f1f1
+}
+.btn55 {
+	background: #efefef url(../images/middlebg.png) repeat-x 0 0;
+	border: 1px solid #d5d5d5;
+	padding: 8px 6px 2px 6px;
+	display: inline-block
+}
+.btn55:hover {
+	background: #f6f6f6
+}
+.btn55:active {
+	background: #f1f1f1
+}
+.btn55 span {
+	display: block;
+	padding: 5px 5px 0 5px;
+	color: #595858
+}
+.btnIconLeft {
+	border: 1px solid #d5d5d5;
+	background: url(../images/leftNavBg.png) repeat-x 0 0;
+	display: inline-block;
+	color: #595858
+}
+.btnIconLeft:hover {
+	background: #f6f6f6;
+	color: #b55d5c
+}
+.btnIconLeft:active {
+	background: #f1f1f1
+}
+.btnIconLeft .icon {
+	float: left;
+	border-right: 1px solid #d5d5d5;
+	padding: 8px
+}
+.btnIconLeft span {
+	display: block;
+	float: left;
+	padding: 5px 10px;
+	font-weight: 700
+}
+.pagination {
+	margin: auto;
+	width: auto;
+	text-align: center;
+	margin-top: 40px
+}
+.pages li.prev {
+	margin-right: 15px
+}
+.pages li.next {
+	margin-left: 15px
+}
+.pages li {
+	display: inline;
+	margin: 0 2px
+}
+.pages li a {
+	height: 25px;
+	padding: 4px 8px;
+	text-decoration: none;
+	color: #666;
+	font-weight: 700;
+	background: url(../images/ui/pagination.png) repeat-x 0 0;
+	border: 1px solid #d5d5d5;
+	font-size: 11px
+}
+.pages li a:hover {
+	background: #efefef
+}
+.pages li .active {
+	background-position: 0 -26px;
+	color: #fff;
+	border-color: #687282
+}
+.pages li .active:hover {
+	background: #687282
+}
+.numberLeft,
+.numberTop {
+	text-align: center;
+	background: url(../images/number.png) repeat-x;
+	display: inline-block;
+	padding: 1px 5px;
+	color: #fff;
+	-moz-border-radius: 2px;
+	-webkit-border-radius: 2px;
+	-khtml-border-radius: 2px;
+	border-radius: 2px;
+	float: right;
+	margin: 10px 15px 10px -5px;
+	font-size: 11px;
+	line-height: 14px
+}
+.numberTop {
+	margin: 10px 15px 10px -5px;
+	padding: 1px 5px!important
+}
+.numberMiddle {
+    margin: 0;
+    position: absolute;
+    top: -3px;
+    right: 3px;
+    border-radius: 3px;
+    padding: 7px !important;
+    text-align: center;
+    background: #f00;
+    color: #fff;
+    line-height: 1px;
+}
+.numberLeft {
+	margin: 0;
+	position: absolute;
+	top: 12px;
+	right: 8px;
+	font-size: 11px;
+	font-family: Arial, Helvetica, sans-serif;
+	float: none;
+	background: url(../images/number.png) repeat-x!important;
+	padding: 1px 5px!important
+}
+#topNav {
+	height: 36px;
+	display: block
+}
+.fixed {
+	position: fixed;
+	background-color: #262b2f;
+	width: 100%;
+	height: 5%;
+	color: #eee;
+	border-bottom: 1px solid #fff;
+	z-index: 999
+}
+.welcome {
+	float: left
+}
+.welcome img {
+	float: left;
+	margin: 8px 8px 8px 0
+}
+.welcome span {
+	padding: 8px 5px;
+	display: block;
+	white-space: nowrap;
+	float: left;
+	font-size: 11px
+}
+.userNav {
+	float: right;
+	z-index: 6000;
+	position: relative;
+	font-size: 11px
+}
+.userNav .lastNav {
+	width: 2px;
+	height: 36px;
+	background: url(../images/navSep.png) repeat-y;
+	position: absolute;
+	top: 0;
+	right: 0
+}
+.userNav ul {
+	margin-right: 2px
+}
+.userNav ul li {
+	display: inline;
+	float: left;
+	position: relative;
+	cursor: pointer;
+	border-right: 1px solid #2f2f2f
+}
+.userNav ul li:first-child {
+	border-left: 1px solid #2f2f2f
+}
+.userNav ul li a {
+	color: #eee;
+	text-decoration: none;
+	display: block;
+	float: left
+}
+.selected,
+.userNav ul li:hover {
+	background: #212121
+}
+.userNav ul li span {
+	display: block;
+	padding: 8px 14px 8px 8px;
+	float: left
+}
+.userNav ul li img {
+	float: left;
+	display: block;
+	padding: 6px 2px 11px 14px
+}
+.userNav ul li ul {
+	position: absolute;
+	left: -1px;
+	display: none;
+	top: 35px;
+	margin-top: 0;
+	background: #2f2f2f;
+	padding: 0 1px 1px 1px;
+	border: 1px solid #1d1d1d;
+	z-index: 100
+}
+.userNav ul li ul li {
+	display: block;
+	float: none;
+	border-top: 1px solid #2f2f2f;
+	background: #212121;
+	border-right: none;
+	border-bottom: 1px solid #141414
+}
+.userNav ul li ul li:first-child {
+	border-left: none!important
+}
+.userNav ul li ul li a {
+	width: 100px;
+	padding: 6px 10px 7px 36px;
+	font-size: 11px;
+	text-transform: none;
+	color: #c5c5c5;
+	font-weight: 400;
+	background-color: none;
+	float: none
+}
+.userNav ul li ul li a:hover {
+	background-color: none;
+	font-weight: 400;
+	color: #a4a4a4
+}
+.userNav ul li ul li:hover {
+	background: #1d1d1d!important
+}
+.sAdd {
+	background: url(../images/icons/topnav/subAdd.png) no-repeat 15px 13px
+}
+.sInbox {
+	background: url(../images/icons/topnav/subInbox.png) no-repeat 14px 12px
+}
+.sOutbox {
+	background: url(../images/icons/topnav/subOutbox.png) no-repeat 14px 11px
+}
+.sTrash {
+	background: url(../images/icons/topnav/subTrash.png) no-repeat 14px 12px
+}
+#header {
+	height: 106px;
+	clear: both
+}
+.logo {
+	float: left;
+	margin-top: 30px
+}
+.middleNav {
+	float: right;
+	margin-right: 1px
+}
+.middleNav ul {
+	margin-top: 25px
+}
+.middleNav ul li {
+	height: 55px;
+	text-align: center;
+	display: block;
+	float: left;
+	margin-left: 25px;
+	position: relative;
+	min-width: 64px
+}
+.middleNav ul li:first-child {
+	margin: 0
+}
+.middleNav ul li a {
+	display: block;
+	border: 1px solid #d5d5d5;
+	background: url(../images/middlebg.png) repeat-x 0 0;
+	-moz-border-radius: 2px;
+	-webkit-border-radius: 2px;
+	-khtml-border-radius: 2px;
+	border-radius: 2px;
+	color: #595858;
+	font-size: 12px;
+	position: relative;
+	-moz-box-shadow: 0 2px 1px #fff;
+	-webkit-box-shadow: 0 2px 1px #fff;
+	box-shadow: 0 2px 1px #fff
+}
+.middleNav ul li a span {
+	display: block;
+	padding: 34px 10px 0 10px
+}
+.middleNav ul li a span i {
+	margin-top: -26px;
+	margin-bottom: 4px
+}
+.middleNav ul li.iStat a span {
+	background: url(../images/icons/middlenav/graph.png) no-repeat 50% 8px
+}
+.middleNav ul li.iTransactions a span {
+	background: url(../images/icons/middlenav/transfer.png) no-repeat 50% 8px
+}
+.middleNav ul li.iPlugin a span {
+	background: url(../images/icons/middlenav/electroPlug.png) no-repeat 50% 8px
+}
+.middleNav ul li.iMegaphone a span {
+	background: url(../images/icons/middlenav/megaphone.png) no-repeat 50% 8px
+}
+.middleNav ul li a:hover {
+	background: #f6f6f6
+}
+.middleNav ul li a:active {
+	background: #f1f1f1
+}
+.leftNav {
+	width: 212px;
+	max-width: 36%;
+	margin-top: -1px;
+	float: left;
+	margin-bottom: 80px;
+	margin-right: 41px
+}
+.leftNav .last {
+	border-bottom: none
+}
+.leftNav ul li {
+	position: relative
+}
+.leftNav ul li a {
+	color: #494949;
+	font-size: 15px;
+	display: block;
+	background: #efefef url(../images/leftNavBg.png) repeat-x 0 0;
+	border: 1px solid #d5d5d5;
+	margin-top: 1px
+}
+.leftNav ul li a.active,
+.leftNav ul li a:hover {
+	background: url(../images/darkBg.jpg) repeat-x;
+	color: #fff;
+	border: 1px solid #3c4049
+}
+.leftNav ul li a span {
+	padding: 9px 0 9px 0;
+	display: block
+}
+.leftNav ul li a span i {
+	margin: -3px 10px
+}
+.leftNav ul li.home a span {
+	background: url(../images/icons/dark/home.png) no-repeat 10px
+}
+.leftNav ul li.transactions a span {
+	background: url(../images/icons/dark/transfer.png) no-repeat 10px
+}
+.leftNav ul li.dash a span {
+	background-image: url(../images/icons/dark/download.png)
+}
+.leftNav ul li.forms a span {
+	background-image: url(../images/icons/dark/pencil.png)
+}
+.leftNav ul li.gallery a span {
+	background-image: url(../images/icons/dark/preview.png)
+}
+.leftNav ul li.typo span {
+	background-image: url(../images/icons/dark/create.png)
+}
+.leftNav ul li.tables a span {
+	background-image: url(../images/icons/dark/frames.png)
+}
+.leftNav ul li.cal a span {
+	background-image: url(../images/icons/dark/dayCalendar.png)
+}
+.leftNav ul li.errors a span {
+	background-image: url(../images/icons/dark/alert.png)
+}
+.leftNav ul li.files a span {
+	background-image: url(../images/icons/dark/files.png)
+}
+.leftNav ul li.login a span {
+	background-image: url(../images/icons/dark/user.png)
+}
+.leftNav ul li.widgets a span {
+	background-image: url(../images/icons/dark/full.png)
+}
+ul.sub {
+	padding-left: 25px;
+	border-top: none;
+	background: #373d42;
+}
+ul.sub li {
+	padding: 1px
+}
+ul.sub li a {
+	background: url(../images/arrow.gif) no-repeat 8px 16px;
+	border: none;
+	font-family: Arial, Helvetica, sans-serif;
+	color: #a9a9a9;
+	font-size: 11px;
+	padding: 8px 10px 8px 18px
+}
+.sub li a:active,
+ul.sub li a:hover {
+	font-style: normal;
+	border: none;
+	color: #676767;
+	background: url(../images/arrow.gif) no-repeat 8px 16px
+}
+ul.sub li ul {
+	border: none;
+	border-top: 1px solid #c9c9c9
+}
+ul.sub li ul li {
+	padding-left: 10px
+}
+.stats {
+	margin-top: 25px
+}
+.stats ul {
+  display: flex;
+  justify-content: center;
+}
+.stats ul li {
+    float: left;
+    display: inline;
+    margin: 0 50px 0 25px;
+    vertical-align: top;
+    min-width: 20%;
+    align-items: center;
+}
+.stats ul li:first-child {
+    background: #28c77e;
+    border-radius: 3px;
+}
+.stats ul li:nth-child(2) {
+	background: #00C0EF;
+    border-radius: 3px;
+}
+.stats ul li:nth-child(3) {
+    background: #f95353;
+    border-radius: 3px;
+}
+.stats ul li:last-child {
+    background: #e3971f;
+    border-radius: 3px;
+}
+.stats ul li span {
+    color: #ffffff;
+    font-size: 15px;
+    display: block;
+    vertical-align: middle;
+    line-height: 40px;
+    white-space: nowrap;
+    overflow: hidden;
+}
+.count {
+	font-size: 26px;
+	height: 40px;
+	display: inline-block;
+	float: left;
+	line-height: 41px;
+	padding: 0 10px;
+	margin-right: 10px
+}
+.stats a.blue {
+	background: #0599bd;
+    width: 30px;
+    border-radius: 3px;
+    text-align: center;
+	color: #f7f7f7;
+}
+.stats a.blue:hover {
+	background-position: 0 -41px
+}
+.stats a.blue:active {
+	background-position: 0 -82px
+}
+.stats a.grey {
+	background: #bd852e;
+    width: 30px;
+    border-radius: 3px;
+    text-align: center;
+	color: #f7f7f7;
+}
+.stats a.grey:hover {
+	background-position: 0 -41px
+}
+.stats a.grey:active {
+	background-position: 0 -82px
+}
+.stats a.green {
+	background: #10ad65;
+    width: 30px;
+    border-radius: 3px;
+    text-align: center;
+	color: #f7f7f7;
+}
+.stats a.green:hover {
+	background-position: 0 -41px
+}
+.stats a.green:active {
+	background-position: 0 -82px
+}
+.stats a.red {
+	background: #cd2929;
+    width: 30px;
+    border-radius: 3px;
+    text-align: center;
+	color: #f7f7f7;
+}
+.stats a.red:hover {
+	background-position: 0 -41px
+}
+.stats a.red:active {
+	background-position: 0 -82px
+}
+.fc-button-prev .fc-button-content {
+	width: 10px;
+	background: url(../images/leftArrow.png) no-repeat 15px 13px
+}
+.fc-button-next .fc-button-content {
+	width: 10px;
+	background: url(../images/rightArrow.png) no-repeat 15px 13px
+}
+.widget {
+	margin-top: 40px;
+	border: 1px solid #d5d5d5;
+	display: block;
+	background: #fafafa;
+	clear: both;
+	border-top: none
+}
+.widgetS {
+	margin-top: 40px;
+	border: 1px solid #d5d5d5;
+	display: block;
+	background: #fafafa;
+	border-top: none;
+	min-width: 25%;
+	float: left;
+	margin-right: 40px
+}
+.head {
+    background: #ffffff;
+    height: 38px;
+    border-top: 10px solid #547fa9;
+    border-bottom: 1px solid #d5d5d5;
+	position: relative
+}
+.table h5,
+.widget .head h5 {
+	font-weight: 400;
+    color: #053a6e;
+	padding: 9px 12px 9px 35px;
+	float: left
+}
+.widget .body {
+	padding: 12px 14px
+}
+.accordion-close h5,
+.widget .normal h5 {
+	background: url(../images/aNormal.png) no-repeat 15px 15px;
+	padding: 9px 12px 9px 32px!important
+}
+.accordion-open h5,
+.widget .inactive h5 {
+	background: url(../images/aInactive.png) no-repeat 12px 17px;
+	padding: 9px 12px 9px 32px!important
+}
+.widget .num {
+	float: right;
+	display: inline-block;
+	text-align: center;
+	margin: 9px 9px 0 0;
+	font-size: 11px
+}
+.widget .num span {
+	margin-right: 10px
+}
+.widget .num a {
+	background: url(../images/ui/numDataBg.png) repeat-x;
+	height: 19px;
+	padding: 2px 5px;
+	color: #fefefe
+}
+.widget .num a.blueNum {
+	background-position: 0 0;
+	border: 1px solid #606873
+}
+.widget .num a.blueNum:hover {
+	background-position: 0 -19px
+}
+.widget .num a.blueNum:active {
+	background-position: 0 -38px
+}
+.widget .num a.redNum {
+	background-position: 0 -57px;
+	border: 1px solid #9d382f
+}
+.widget .num a.redNum:hover {
+	background-position: 0 -76px
+}
+.widget .num a.redNum:active {
+	background-position: 0 -95px
+}
+.widget .num a.greenNum {
+	background-position: 0 -114px;
+	border: 1px solid #218516
+}
+.widget .num a.greenNum:hover {
+	background-position: 0 -133px
+}
+.widget .num a.greenNum:active {
+	background-position: 0 -152px
+}
+.widget .loader {
+	float: right;
+	margin: 14px 12px 0 0
+}
+.userLink {
+	font-size: 16px;
+	padding-top: 3px;
+	display: block;
+	margin-left: 25px;
+	white-space: nowrap
+}
+.userWidget {
+	padding: 6px 12px 0 12px;
+	display: block;
+	float: left
+}
+.inactive,
+.normal {
+	cursor: pointer
+}
+.accordion-close,
+.normal {
+	border-bottom: none
+}
+.standalone {
+	float: left;
+	width: 300px;
+	margin-left: 40px
+}
+.standalone:first-child {
+	margin-left: 0
+}
+.pics {
+	padding-bottom: 14px;
+	margin: auto;
+	padding: 0 6px 14px 6px;
+	text-align: center
+}
+.pics ul li {
+	display: inline-block;
+	height: 102px;
+	margin: 16px 6px 0 6px;
+	border: 1px solid #d5d5d5;
+	position: relative
+}
+.pics ul li:hover {
+	border-color: #bbc1c9
+}
+.pics .actions {
+	background: #000;
+	opacity: .8;
+	position: absolute;
+	bottom: 0;
+	right: 0;
+	display: none
+}
+.pics .actions a {
+	color: #fff;
+	font-size: 11px;
+	display: block;
+	padding: 3px 4px;
+	float: left
+}
+.pics .actions a:first-child {
+	padding-right: 0
+}
+ul.tabs {
+	background: #fff;
+	height: 38px;
+	border-bottom: 1px solid #d5d5d5;
+    border-top: 10px solid #547fa9
+}
+ul.tabs li {
+	float: left;
+	height: 38px;
+	line-height: 39px;
+	border-left: none;
+	overflow: hidden;
+	position: relative;
+	border-right: 1px solid #d5d5d5;
+	font-size: 15px
+}
+ul.tabs li a {
+	text-decoration: none;
+	display: block;
+	padding: 0 12px;
+	outline: 0;
+	color: #053a6e
+}
+ul.tabs li a:hover {
+	color: #797979
+}
+html ul.tabs li.activeTab {
+	background-color: #fafafa;
+	height: 39px
+}
+html ul.tabs li.activeTab a {
+	color: #053a6e
+}
+.tab_container {
+	overflow: hidden;
+	clear: both;
+	float: left;
+	width: 100%
+}
+.tab_content {
+	padding: 10px 12px
+}
+.tabsRight {
+	position: relative
+}
+.tabsRight ul.tabs {
+	float: right;
+	background: url(../images/leftNavBg.png) repeat-x;
+	height: 38px;
+	border-bottom: 1px solid #d5d5d5;
+	position: absolute;
+	top: 0;
+	right: 0
+}
+.tabsRight ul.tabs li {
+	border-left: 1px solid #d5d5d5;
+	border-right: none
+}
+.tabsRight ul.tabs li.activeTab {
+	background-color: #fafafa;
+	height: 38px
+}
+.twoOne {
+	width: 50%
+}
+.breadCrumb,
+.btn14,
+.btn55,
+.content .title,
+.count,
+.customfile,
+.earnings,
+.errorPage,
+.leftNav ul li a,
+.listData .cNote,
+.loginPanel,
+.pages li a,
+.table,
+.widget,
+.widget .num a,
+a.count1 {
+	-moz-border-radius: 2px;
+	-webkit-border-radius: 2px;
+	-khtml-border-radius: 2px;
+	border-radius: 2px
+}
+.widgets {
+	clear: both
+}
+.widgets .left {
+	float: left;
+	width: 48%;
+	margin-right: 4%
+}
+.widgets .right {
+	float: right;
+	width: 48%
+}
+.content {
+	padding-bottom: 80px;
+	overflow: hidden
+}
+.content .title {
+	background: url(../images/darkBg.jpg) repeat-x;
+	height: 36px;
+	-moz-box-shadow: 0 1px 0 #fff;
+	-webkit-box-shadow: 0 1px 0 #fff;
+	box-shadow: 0 1px 0 #fff
+}
+.content .title h5 {
+	float: left;
+	color: #fafafa;
+	font-weight: 400;
+	display: block;
+	padding: 7px 15px
+}
+.supTicket {
+	background: url(../images/linesSep.png) 0 0 repeat-x;
+	padding: 12px 12px 15px 12px
+}
+.supTicket .issueType {
+	color: #515e70;
+	clear: both;
+	font-weight: 700;
+	background: url(../images/dashed.png) repeat-x 0
+}
+.supTicket .issueType .issueInfo {
+	float: left;
+	display: block;
+	background: #fafafa;
+	padding-right: 5px
+}
+.supTicket .issueType .issueNum {
+	float: right;
+	display: block;
+	background: #fafafa;
+	padding-left: 5px;
+	padding-right: 1px
+}
+.issueSummary {
+	clear: both;
+	padding-top: 14px
+}
+.issueSummary img {
+	border: 1px solid #d5d5d5
+}
+.ticketInfo ul {
+	float: left;
+	width: 100%;
+	margin-bottom: -6px
+}
+.ticketInfo ul li {
+	width: 50%;
+	margin-top: -2px;
+	display: inline-block;
+	float: left;
+	margin-bottom: 6px;
+	padding: 0
+}
+.ticketInfo ul li.even {
+	text-align: right
+}
+.ticketInfo {
+	margin-top: -3px;
+	margin-bottom: -11px;
+	margin-left: 50px
+}
+.userSummary {
+	background: url(../images/linesSep.png) 0 100% repeat-x
+}
+.userSummary ul li {
+	width: 127px;
+	display: block;
+	float: left;
+	margin-bottom: 12px;
+	margin-top: -1px
+}
+.userSummary ul li.even {
+	text-align: right
+}
+.userSummary .infoLeft {
+	width: 153px;
+	float: left
+}
+.userSummary .infoLeft div,
+.userSummary .infoRight div {
+	padding-top: 12px
+}
+.userSummary .infoLeft div:first-child,
+.userSummary .infoRight div:first-child {
+	padding: 0
+}
+.userSummary .infoRight {
+	width: 153px;
+	float: right;
+	text-align: right
+}
+.userAlt {
+	padding: 0 12px;
+	background: url(../images/leftNavBg.png) repeat-x
+}
+.userAlt img {
+	float: left;
+	display: block;
+	margin: 4px 8px 0 0
+}
+.userEmail {
+	display: block;
+	white-space: nowrap
+}
+.botRow span {
+	float: left;
+	display: block;
+	margin-right: 10px
+}
+#eq span {
+	height: 120px;
+	float: left;
+	margin-right: 30px;
+	display: block
+}
+.searchWidget {
+	position: relative;
+	margin-top: 40px
+}
+.searchWidget input[type=text] {
+	background: #fafafa;
+	border: 1px solid #d5d5d5;
+	padding: 10px;
+	width: 100%;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-ms-box-sizing: border-box;
+	box-sizing: border-box
+}
+.searchWidget input[type=submit] {
+	background: url(../images/searchBtn.png) no-repeat 0 0;
+	position: absolute;
+	top: 0;
+	right: 0;
+	border: none;
+	width: 36px;
+	height: 36px
+}
+.webStatsLink {
+	font-size: 16px;
+	color: #b55d5c;
+	font-weight: 700
+}
+.statMinus,
+.statPlus {
+	padding-left: 12px;
+	font-size: 12px
+}
+.statPlus {
+	color: #549332;
+	background: url(../images/topArrow.png) no-repeat 0 3px
+}
+.statMinus {
+	color: #b55d5c;
+	background: url(../images/botArrow.png) no-repeat 0 3px
+}
+.menu_body {
+	display: none;
+	padding: 12px 14px
+}
+.acc .head {
+	margin-bottom: -1px;
+	cursor: pointer
+}
+.acc .head h5 {
+	padding: 9px 14px
+}
+.autoUpdate,
+.bars,
+.chart {
+	height: 220px;
+	z-index: 90;
+	margin: 10px 0 0 0;
+	max-width: 100%
+}
+.pieWidget {
+	width: 100%;
+	height: 316px;
+	margin: 0 auto
+}
+#footer {
+	clear: both;
+	background: url(../images/topNav.jpg) repeat;
+	width: 100%;
+	color: #eee;
+	margin-top: 42px;
+	position: absolute;
+	bottom: 0
+}
+#footer span {
+	color: #696969;
+	padding: 9px 5px;
+	display: block;
+	font-size: 11px
+}
+#footer span a {
+	color: #eee
+}
+.tableStatic thead td {
+	padding: 3px 0 2px 0;
+	text-align: center;
+	border-left: 1px solid #d5d5d5;
+	background: #efefef url(../images/leftNavBg.png) repeat-x;
+	border-bottom: 1px solid #d5d5d5;
+	font-size: 11px;
+	color: #878787
+}
+.tableStatic thead td:first-child {
+	border-left: none
+}
+.tableStatic tbody tr {
+	border-top: 1px solid #e7e7e7
+}
+.tableStatic tbody tr:nth-child(even) {
+	background-color: #f5f5f5
+}
+.tableStatic tbody td {
+	border-left: 1px solid #e7e7e7;
+	padding: 8px 10px;
+	vertical-align: middle
+}
+.tableStatic tbody td:first-child {
+	border-left: none
+}
+.mainForm label {
+	margin-right: 15px;
+	display: block;
+	float: left;
+	padding: 4px 10px
+}
+.datepicker {
+	width: 58px!important;
+	cursor: pointer
+}
+.colorpick {
+	width: 58px!important;
+	float: left;
+	cursor: pointer
+}
+.pick {
+	width: 16px;
+	height: 16px;
+	float: left;
+	background: url(../images/color.png) no-repeat 0;
+	margin: 2px 5px;
+	cursor: pointer;
+	padding: 4px 0!important
+}
+.colorP {
+	position: relative;
+	width: 58px
+}
+.multiple {
+	width: 100%;
+	height: 200px;
+	padding: 5px;
+	border: 1px solid #d5d5d5
+}
+.sliderSpecs label {
+	padding: 0!important;
+	font-size: 11px;
+	line-height: 14px
+}
+.sliderSpecs input {
+	float: left;
+	width: auto!important;
+	background: 0 0!important;
+	border: 0!important;
+	font-weight: 700;
+	color: #3a6fa5;
+	padding: 0!important;
+	margin-left: 10px
+}
+.moreFields ul li {
+	float: left;
+	width: 8%;
+	margin: 0
+}
+.moreFields ul li.sep {
+	padding: 3px 5px 3px 6px;
+	display: block;
+	margin: 0;
+	width: auto;
+	color: #d5d5d5
+}
+.moreFields ul li span {
+	display: block;
+	padding: 3px 12px;
+	white-space: nowrap
+}
+.moreFields ul li div.selector span {
+	padding: 0
+}
+.itemDisabled {
+	color: #b7b7b7
+}
+.rowElem {
+	clear: both;
+	border-top: 1px solid #e7e7e7;
+	padding: 10px 16px;
+	position: relative
+}
+.formRight {
+	float: right;
+	width: 76%;
+	margin: 12px 0;
+	display: block;
+	position: relative
+}
+.formRight label,
+.loginRow label {
+	cursor: pointer
+}
+.formBottom {
+	margin: 12px 12px 12px 0
+}
+.rowElem>label {
+	padding: 15px 0;
+	width: 14%
+}
+.rowElem .topLabel {
+	padding: 5px 12px 12px 0;
+	width: 100%
+}
+#valid input {
+	position: relative
+}
+.mainForm input[type=email],
+.mainForm input[type=password],
+.mainForm input[type=text],
+.mainForm textarea {
+	background: #fff;
+	width: 100%;
+	border: 1px solid #d5d5d5;
+	padding: 5px;
+	font-size: 11px;
+	font-family: Arial, Helvetica, sans-serif;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-ms-box-sizing: border-box;
+	box-sizing: border-box
+}
+.mainForm input[type=password]:hover,
+.mainForm input[type=text]:hover,
+.mainForm textarea:hover {
+	background: #fcfcfc;
+	border: 1px solid #d1d1d1
+}
+.mainForm input[type=password]:focus,
+.mainForm input[type=text]:focus,
+.mainForm textarea:focus {
+	border: 1px solid #bbc1c9;
+	background: #fff
+}
+.submitForm {
+	float: right;
+	margin: 1px 16px 22px 16px
+}
+div.selector {
+	position: relative;
+	height: 26px;
+	background: url(../images/chosenSelect.png) repeat-x;
+	float: left;
+	width: 190px;
+	position: relative;
+	padding-left: 10px;
+	border: 1px solid #d5d5d5
+}
+div.selector span {
+	width: 190px;
+	cursor: pointer;
+	position: absolute;
+	right: -1px;
+	height: 26px;
+	background: url(../images/forms/select_right.png) no-repeat center right;
+	top: 0;
+	line-height: 27px;
+	font-size: 11px
+}
+div.selector select {
+	width: 202px;
+	cursor: pointer;
+	font-size: 12px;
+	position: absolute;
+	height: 26px;
+	top: 2px;
+	left: -1px
+}
+li div.selector {
+	padding-left: 13px
+}
+li div.selector span {
+	top: -3px
+}
+.dataTables_length div.selector {
+	width: 45px;
+	float: left;
+	height: 20px;
+	padding-left: 8px
+}
+.dataTables_length div.selector span {
+	width: 45px;
+	height: 22px;
+	background: url(../images/forms/select_right_datatable.png) no-repeat center right;
+	line-height: 22px;
+	top: -1px
+}
+.dataTables_length div.selector select {
+	width: 65px;
+	left: -5px;
+	height: 22px
+}
+div.checker {
+	width: 15px;
+	height: 15px;
+	position: relative;
+	float: left;
+	margin-top: 6px
+}
+div.checker input {
+	width: 15px;
+	height: 15px;
+	opacity: 0;
+	display: inline-block;
+	background: 0 0
+}
+div.checker span {
+	background: transparent url(../images/forms/checkbox.png) no-repeat 0 0;
+	vertical-align: middle;
+	height: 15px;
+	width: 15px;
+	display: -moz-inline-box;
+	display: inline-block;
+	text-align: center
+}
+div.checker span.checked {
+	background-position: center bottom
+}
+div.radio {
+	width: 18px;
+	height: 18px;
+	position: relative;
+	float: left;
+	margin-top: 5px
+}
+div.radio input {
+	opacity: 0;
+	text-align: center;
+	display: inline-block;
+	background: 0 0;
+	width: 18px;
+	height: 18px
+}
+div.radio span {
+	background: transparent url(../images/forms/radio.png) no-repeat 0 0;
+	vertical-align: middle;
+	height: 15px;
+	width: 15px;
+	display: block;
+	display: -moz-inline-box;
+	display: inline-block;
+	text-align: center
+}
+div.radio span.checked {
+	background-position: center bottom
+}
+div.uploader {
+	width: 240px;
+	position: relative;
+	overflow: hidden;
+	border: 1px solid #d5d5d5;
+	background: #fff;
+	padding: 2px 2px 2px 8px
+}
+div.uploader span.action {
+	width: 22px;
+	background: #fff url(../images/addFiles.png) no-repeat 0 0;
+	height: 22px;
+	font-size: 11px;
+	font-weight: 700;
+	cursor: pointer;
+	float: right;
+	text-indent: -9999px;
+	display: inline;
+	overflow: hidden;
+	cursor: pointer
+}
+div.uploader:hover span.action {
+	background-position: 0 -27px
+}
+div.uploader:active span.action {
+	background-position: 0 -54px
+}
+div.uploader span.filename {
+	color: #777;
+	max-width: 200px;
+	font-size: 11px;
+	line-height: 22px;
+	float: left;
+	display: block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	cursor: default
+}
+div.uploader input {
+	width: 266px;
+	opacity: 0;
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	float: right;
+	height: 26px;
+	border: none;
+	cursor: pointer
+}
+.uploader {
+	display: -moz-inline-box;
+	display: inline-block;
+	vertical-align: middle;
+	zoom: 1
+}
+.list .legend {
+	display: block;
+	font-weight: 700;
+	padding-bottom: 4px
+}
+.list ul li {
+	padding: 0 0 0 15px
+}
+.plusBlue li {
+	background: url(../images/icons/lists/plusBlue.png) no-repeat 0 7px
+}
+.plusRed li {
+	background: url(../images/icons/lists/plusRed.png) no-repeat 0 7px
+}
+.plusGrey li {
+	background: url(../images/icons/lists/plusGrey.png) no-repeat 0 7px
+}
+.plusGreen li {
+	background: url(../images/icons/lists/plusGreen.png) no-repeat 0 7px
+}
+.tipBlue ul li {
+	background: url(../images/icons/lists/tipBlue.png) no-repeat 0 6px
+}
+.tipRed ul li {
+	background: url(../images/icons/lists/tipRed.png) no-repeat 0 6px
+}
+.tipGrey ul li {
+	background: url(../images/icons/lists/tipGrey.png) no-repeat 0 6px
+}
+.tipGreen ul li {
+	background: url(../images/icons/lists/tipGreen.png) no-repeat 0 6px
+}
+.arrowBlue ul li {
+	background: url(../images/icons/lists/arrowBlue.png) no-repeat 1px 6px
+}
+.arrowRed ul li {
+	background: url(../images/icons/lists/arrowRed.png) no-repeat 1px 6px
+}
+.arrowGrey ul li {
+	background: url(../images/icons/lists/arrowGrey.png) no-repeat 1px 6px
+}
+.arrowGreen ul li {
+	background: url(../images/icons/lists/arrowGreen.png) no-repeat 1px 6px
+}
+.arrow2Blue ul li {
+	background: url(../images/icons/lists/arrow2Blue.png) no-repeat 1px 6px
+}
+.arrow2Red ul li {
+	background: url(../images/icons/lists/arrow2Red.png) no-repeat 1px 6px
+}
+.arrow2Grey ul li {
+	background: url(../images/icons/lists/arrow2Grey.png) no-repeat 1px 6px
+}
+.arrow2Green ul li {
+	background: url(../images/icons/lists/arrow2Green.png) no-repeat 1px 6px
+}
+.tipsy {
+	padding: 4px;
+	font-size: 10px;
+	opacity: .8;
+	background-repeat: no-repeat;
+	background-image: url(../images/tipsy.gif)
+}
+.tipsy-inner {
+	padding: 2px 8px 2px 8px;
+	background-color: #000;
+	color: #fff;
+	max-width: 200px;
+	text-align: center
+}
+.tipsy-inner {
+	-moz-border-radius: 3px;
+	-webkit-border-radius: 3px
+}
+.tipsy-north {
+	background-position: top center
+}
+.tipsy-south {
+	background-position: bottom center
+}
+.tipsy-east {
+	background-position: right center
+}
+.tipsy-west {
+	background-position: left center
+}
+.nNote {
+	cursor: pointer;
+	clear: both;
+	margin: 20px 0 20px 0
+}
+.nNote strong {
+	margin-right: 5px
+}
+.nNote p {
+	font-size: 11px;
+	padding: 10px 25px 10px 54px;
+	margin: 0;
+	color: #565656
+}
+.nMessage p {
+	font-size: 11px
+}
+.nWarning {
+	background: #ffe9ad url(../images/icons/notifications/error.png) no-repeat 15px center;
+	border: 1px solid #eac572;
+	color: #826200
+}
+.nSuccess {
+	background: #effeb9 url(../images/icons/notifications/accept.png) no-repeat 15px center;
+	border: 1px solid #c1d779;
+	color: #3c5a01
+}
+.nFailure {
+	background: #fccac1 url(../images/icons/notifications/exclamation.png) no-repeat 15px center;
+	border: 1px solid #e18b7c;
+	color: #ac260f
+}
+.nInformation {
+	background: #d1e4f3 url(../images/icons/notifications/information.png) no-repeat 15px center;
+	border: 1px solid #99c4ea;
+	color: #235685
+}
+.nLightbulb {
+	background: #fef0cb url(../images/icons/notifications/lightbulb.png) no-repeat 15px center;
+	border: 1px solid #d3a350;
+	color: #835f21
+}
+.nMessages {
+	background: #9ddfff url(../images/icons/notifications/email.png) no-repeat 15px center;
+	border: 1px solid #42b4ff;
+	color: #835f21
+}
+.table {
+	margin-top: 40px;
+	border: 1px solid #d5d5d5;
+	border-top: none
+}
+.headTitle {
+	background: #efefef url(../images/leftNavBg.png) repeat-x;
+	height: 37px;
+	border-bottom: 1px solid #d5d5d5
+}
+.ui-spinner {
+	width: 10em;
+	display: block;
+	position: relative;
+	overflow: hidden;
+	border: 1px solid #d5d5d5;
+	background: url(../images/forms/spinnerBg.png) repeat-x top left!important;
+	height: 25px;
+	padding: 0 6px
+}
+.ui-spinner-disabled {
+	background: #f4f4f4;
+	color: #ccc
+}
+.ui-spinner input.ui-spinner-box {
+	border: none!important;
+	background: 0 0!important;
+	padding: 6px 0
+}
+.ui-spinner-down,
+.ui-spinner-up {
+	width: 18px;
+	padding: 0;
+	margin: 0;
+	z-index: 100;
+	position: absolute;
+	right: 0;
+	cursor: default;
+	border: none
+}
+.ui-spinner-up {
+	background: url(../images/forms/spinnerTop.png) no-repeat;
+	height: 13px;
+	top: 0
+}
+.ui-spinner-down {
+	height: 12px;
+	bottom: 0;
+	background: url(../images/forms/spinnerBottom.png) no-repeat
+}
+.ui-spinner-list,
+.ui-spinner-listitem {
+	margin: 0;
+	padding: 0;
+	font-size: 11px
+}
+.ui-spinner ul li,
+.ui-spinner-data {
+	line-height: 25px;
+	height: 25px
+}
+div.jGrowl {
+	z-index: 9999;
+	color: #fff;
+	font-size: 12px
+}
+div.ie6.top-right {
+	right: auto;
+	bottom: auto;
+	left: expression((0 - jGrowl.offsetWidth + (document.documentElement.clientWidth ? document.documentElement.clientWidth: document.body.clientWidth) + (ignoreMe2=document.documentElement.scrollLeft ? document.documentElement.scrollLeft: document.body.scrollLeft)) +'px');
+	top: expression((0 + (ignoreMe=document.documentElement.scrollTop ? document.documentElement.scrollTop: document.body.scrollTop)) +'px')
+}
+div.ie6.top-left {
+	left: expression((0 + (ignoreMe2=document.documentElement.scrollLeft ? document.documentElement.scrollLeft: document.body.scrollLeft)) +'px');
+	top: expression((0 + (ignoreMe=document.documentElement.scrollTop ? document.documentElement.scrollTop: document.body.scrollTop)) +'px')
+}
+div.ie6.bottom-right {
+	left: expression((0 - jGrowl.offsetWidth + (document.documentElement.clientWidth ? document.documentElement.clientWidth: document.body.clientWidth) + (ignoreMe2=document.documentElement.scrollLeft ? document.documentElement.scrollLeft: document.body.scrollLeft)) +'px');
+	top: expression((0 - jGrowl.offsetHeight + (document.documentElement.clientHeight ? document.documentElement.clientHeight: document.body.clientHeight) + (ignoreMe=document.documentElement.scrollTop ? document.documentElement.scrollTop: document.body.scrollTop)) +'px')
+}
+div.ie6.bottom-left {
+	left: expression((0 + (ignoreMe2=document.documentElement.scrollLeft ? document.documentElement.scrollLeft: document.body.scrollLeft)) +'px');
+	top: expression((0 - jGrowl.offsetHeight + (document.documentElement.clientHeight ? document.documentElement.clientHeight: document.body.clientHeight) + (ignoreMe=document.documentElement.scrollTop ? document.documentElement.scrollTop: document.body.scrollTop)) +'px')
+}
+div.ie6.center {
+	left: expression((0 + (ignoreMe2=document.documentElement.scrollLeft ? document.documentElement.scrollLeft: document.body.scrollLeft)) +'px');
+	top: expression((0 + (ignoreMe=document.documentElement.scrollTop ? document.documentElement.scrollTop: document.body.scrollTop)) +'px');
+	width: 100%
+}
+div.jGrowl {
+	position: absolute
+}
+body>div.jGrowl {
+	position: fixed
+}
+div.jGrowl.top-left {
+	left: 0;
+	top: 0
+}
+div.jGrowl.top-right {
+	right: 0;
+	top: 36px
+}
+div.jGrowl.bottom-left {
+	left: 0;
+	bottom: 0
+}
+div.jGrowl.bottom-right {
+	right: 0;
+	bottom: 0
+}
+div.jGrowl.center {
+	top: 0;
+	width: 50%;
+	left: 25%
+}
+div.center div.jGrowl-closer,
+div.center div.jGrowl-notification {
+	margin-left: auto;
+	margin-right: auto
+}
+div.jGrowl div.jGrowl-closer,
+div.jGrowl div.jGrowl-notification {
+	background-color: #000;
+	opacity: .85;
+	zoom: 1;
+	width: 235px;
+	padding: 10px;
+	margin-top: 5px;
+	margin-bottom: 5px;
+	font-family: Tahoma, Arial, Helvetica, sans-serif;
+	font-size: 1em;
+	text-align: left;
+	display: none
+}
+div.jGrowl div.jGrowl-notification {
+	min-height: 40px
+}
+div.jGrowl div.jGrowl-closer,
+div.jGrowl div.jGrowl-notification {
+	margin: 10px
+}
+div.jGrowl div.jGrowl-notification div.jGrowl-header {
+	font-weight: 700;
+	font-size: .85em
+}
+div.jGrowl div.jGrowl-notification div.jGrowl-close {
+	z-index: 99;
+	float: right;
+	font-weight: 700;
+	font-size: 1em;
+	cursor: pointer
+}
+div.jGrowl div.jGrowl-closer {
+	padding-top: 4px;
+	padding-bottom: 4px;
+	cursor: pointer;
+	font-size: .9em;
+	font-weight: 700;
+	text-align: center
+}
+@media print {
+	div.jGrowl {
+		display: none
+	}
+}
+#toTop {
+	display: none;
+	text-decoration: none;
+	position: fixed;
+	bottom: 10px;
+	right: 10px;
+	overflow: hidden;
+	width: 21px;
+	height: 21px;
+	border: none;
+	text-indent: -999px;
+	background: url(../images/ui.totop.png) no-repeat left top
+}
+#toTopHover {
+	background: url(../images/ui.totop.png) no-repeat left -22px;
+	width: 21px;
+	height: 21px;
+	display: block;
+	overflow: hidden;
+	float: left;
+	opacity: 0;
+	-moz-opacity: 0
+}
+#toTop:active,
+#toTop:focus {
+	outline: 0
+}
+.listNav {
+	margin: 0 0 10px
+}
+.ln-letters {
+	overflow: hidden;
+	width: 100%;
+	margin-top: -1px;
+	text-align: center
+}
+.ln-letters a {
+	font-size: 11px;
+	display: inline-block;
+	padding: 4px 1%;
+	border: 1px solid #d5d5d5;
+	margin-right: -1px;
+	text-decoration: none;
+	background: #efefef url(../images/leftNavBg.png) repeat-x
+}
+ul.listData {
+	float: right;
+	text-align: right;
+	margin-top: -1px;
+	font-size: 11px
+}
+ul.listData li {
+	display: inline-block;
+	padding: 0 6px 1px 6px!important;
+	border: none!important;
+	margin-left: 6px
+}
+.listData .cNote {
+	background: #fafafa;
+	display: block;
+	padding: 0 6px;
+	border: 1px solid #d5d5d5;
+	color: #878787
+}
+.ln-letters a.ln-selected,
+.ln-letters a:hover {
+	background: #eaeaea
+}
+.ln-letters a.ln-disabled {
+	color: #ccc
+}
+.ln-letter-count {
+	text-align: center;
+	font-size: .8em;
+	line-height: 1;
+	margin-bottom: 3px;
+	color: #369
+}
+#myList>li {
+	padding: 8px 0 8px 12px;
+	border-top: 1px solid #ebebeb
+}
+#myList>li:hover {
+	background: #fff
+}
+#myList>li:first-child {
+	padding-top: 8px
+}
+.SRC_Wrap {
+	height: auto;
+	font-size: 12px
+}
+.SRC_Title {
+	text-align: center;
+	color: #555;
+	border-bottom: 2px solid #999;
+	font-size: 14px;
+	font-family: Verdana, Geneva, sans-serif;
+	padding: 5px;
+	font-weight: 700
+}
+.SRC_Line {
+	width: 100%;
+	background-color: #fafafa;
+	min-height: 28px;
+	line-height: 28px
+}
+.SRC_Line:nth-child(even) {
+	background-color: #f5f5f5
+}
+.SRC_NumBox {
+	width: 5%;
+	float: left
+}
+.SRC_Num {
+	font-family: Verdana, Geneva, sans-serif;
+	font-size: 12px;
+	text-align: right;
+	color: #555;
+	font-weight: 500;
+	padding-right: 2px;
+	width: 100%;
+	height: auto;
+	min-height: 28px;
+	line-height: 28px
+}
+.SRC_CodeContent {
+	white-space: pre-wrap;
+	border-left: 1px solid #d5d5d5;
+	font-size: 12px;
+	padding-left: 6px;
+	font-family: "Courier New", Courier, monospace;
+	margin: 0;
+	min-height: 28px;
+	line-height: 28px
+}
+.SRC_NumContent {
+	text-align: right;
+	margin-right: 4px;
+	color: #555
+}
+.SRC_CodeBox {
+	float: left;
+	width: 95%
+}
+.SC_blue {
+	color: #00f
+}
+.SC_grey {
+	color: grey
+}
+.SC_navy {
+	color: navy
+}
+.SC_green {
+	color: green
+}
+.SC_orange {
+	color: #930
+}
+.SC_red {
+	color: red
+}
+.SC_teal {
+	color: teal
+}
+.SC_gold {
+	color: #fc0
+}
+.SC_pink {
+	color: #ff68a4
+}
+.SC_bold {
+	font-weight: 700
+}
+.module:after {
+	clear: both;
+	content: ".";
+	display: block;
+	height: 0;
+	visibility: hidden
+}
+* html .module {
+	height: 1%;
+	overflow: visible
+}
+.breadCrumbHolder.module {
+    border: solid 1px #547fa9;
+    background: #ffffff;
+	margin-top: 20px
+}
+.breadCrumb {
+	float: left;
+	display: block;
+	height: 21px;
+	overflow: hidden;
+	width: 100%;
+	padding: 5px
+}
+.breadCrumb ul {
+	margin: 0;
+	padding: 0;
+	height: 21px;
+	display: block
+}
+.breadCrumb ul li {
+	display: block;
+	float: left;
+	position: relative;
+	height: 21px;
+	overflow: hidden;
+	line-height: 21px;
+	margin: 0 6px 0 0;
+	padding: 0 12px 0 2px;
+	font-size: .9167em;
+	background: url(../images/Chevron.gif) no-repeat 100% 0
+}
+.breadCrumb ul li div.chevronOverlay {
+	position: absolute;
+	right: 0;
+	top: 0;
+	z-index: 2
+}
+.breadCrumb ul li span {
+	display: block;
+	overflow: hidden
+}
+.breadCrumb ul li a {
+	display: block;
+	position: relative;
+	height: 21px;
+	line-height: 21px;
+	overflow: hidden;
+	float: left
+}
+.breadCrumb ul li.firstB a {
+	height: 16px!important;
+	text-indent: -1000em;
+	width: 16px;
+	padding: 0;
+	margin-top: 2px;
+	overflow: hidden;
+	background: url(../images/IconHome.gif) no-repeat 0 0
+}
+.breadCrumb ul li.firstB a:hover {
+	background-position: 0 -16px
+}
+.breadCrumb ul li.lastB {
+	background: 0 0;
+	margin-right: 0;
+	padding-right: 0
+}
+.chevronOverlay {
+	display: none;
+	background: url(../images/ChevronOverlay.png) no-repeat 100% 0;
+	width: 13px;
+	height: 20px
+}
+.inputContainer {
+	position: relative;
+	float: left
+}
+.formError {
+	position: absolute;
+	top: 300px;
+	left: 280px;
+	display: block;
+	z-index: 500;
+	cursor: pointer
+}
+.ajaxSubmit {
+	padding: 20px;
+	background: #55ea55;
+	border: 1px solid #999;
+	display: none
+}
+.formError .formErrorContent {
+	background: #202020;
+	position: relative;
+	z-index: 5001;
+	color: #fff;
+	width: 160px;
+	font-size: 11px;
+	border: 1px solid #000;
+	padding: 4px 10px 4px 10px;
+	border-radius: 2px;
+	-moz-border-radius: 2px;
+	-webkit-border-radius: 2px
+}
+.greenPopup .formErrorContent {
+	background: #33be40
+}
+.blackPopup .formErrorContent {
+	background: #393939;
+	color: #fff
+}
+.formError .formErrorArrow {
+	width: 15px;
+	margin: -2px 0 0 13px;
+	position: relative;
+	z-index: 5006
+}
+.formError .formErrorArrowBottom {
+	box-shadow: none;
+	-moz-box-shadow: none;
+	-webkit-box-shadow: none;
+	margin: 0 0 0 12px;
+	top: 2px
+}
+.formError .formErrorArrow div {
+	font-size: 0;
+	height: 1px;
+	background: #202020;
+	margin: 0 auto;
+	line-height: 0;
+	font-size: 0;
+	display: block
+}
+.formError .formErrorArrowBottom div {
+	box-shadow: none;
+	-moz-box-shadow: none;
+	-webkit-box-shadow: none
+}
+.greenPopup .formErrorArrow div {
+	background: #33be40
+}
+.blackPopup .formErrorArrow div {
+	background: #393939;
+	color: #fff
+}
+.formError .formErrorArrow .line10 {
+	width: 15px;
+	border: none
+}
+.formError .formErrorArrow .line9 {
+	width: 13px;
+	border: none
+}
+.formError .formErrorArrow .line8 {
+	width: 11px
+}
+.formError .formErrorArrow .line7 {
+	width: 9px
+}
+.formError .formErrorArrow .line6 {
+	width: 7px
+}
+.formError .formErrorArrow .line5 {
+	width: 5px
+}
+.formError .formErrorArrow .line4 {
+	width: 3px
+}
+.formError .formErrorArrow .line3 {
+	width: 1px;
+	border-left: 2px solid #ddd;
+	border-right: 2px solid #ddd;
+	border-bottom: 0 solid #ddd
+}
+.formError .formErrorArrow .line2 {
+	width: 3px;
+	border: none;
+	background: #ddd
+}
+.formError .formErrorArrow .line1 {
+	width: 1px;
+	border: none;
+	background: #ddd
+}
+.colorpicker {
+	width: 356px;
+	height: 176px;
+	overflow: hidden;
+	position: absolute;
+	background: url(../images/colorPicker/colorpicker_background.png);
+	font-family: Arial, Helvetica, sans-serif;
+	display: none
+}
+.colorpicker_color {
+	width: 150px;
+	height: 150px;
+	left: 14px;
+	top: 13px;
+	position: absolute;
+	background: red;
+	overflow: hidden;
+	cursor: crosshair
+}
+.colorpicker_color div {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 150px;
+	height: 150px;
+	background: url(../images/colorPicker/colorpicker_overlay.png)
+}
+.colorpicker_color div div {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 11px;
+	height: 11px;
+	overflow: hidden;
+	background: url(../images/colorPicker/colorpicker_select.gif);
+	margin: -5px 0 0 -5px
+}
+.colorpicker_hue {
+	position: absolute;
+	top: 13px;
+	left: 171px;
+	width: 35px;
+	height: 150px;
+	cursor: n-resize
+}
+.colorpicker_hue div {
+	position: absolute;
+	width: 35px;
+	height: 9px;
+	overflow: hidden;
+	background: url(../images/colorPicker/colorpicker_indic.gif) left top;
+	margin: -4px 0 0 0;
+	left: 0
+}
+.colorpicker_new_color {
+	position: absolute;
+	width: 60px;
+	height: 30px;
+	left: 213px;
+	top: 13px;
+	background: red
+}
+.colorpicker_current_color {
+	position: absolute;
+	width: 60px;
+	height: 30px;
+	left: 283px;
+	top: 13px;
+	background: red
+}
+.colorpicker input {
+	background-color: transparent;
+	border: 1px solid transparent;
+	position: absolute;
+	font-size: 10px;
+	font-family: Arial, Helvetica, sans-serif;
+	color: #898989;
+	top: 4px;
+	right: 11px;
+	text-align: right;
+	margin: 0;
+	padding: 0;
+	height: 11px
+}
+.colorpicker_hex {
+	position: absolute;
+	width: 72px;
+	height: 22px;
+	background: url(../images/colorPicker/colorpicker_hex.png) top;
+	left: 212px;
+	top: 142px
+}
+.colorpicker_hex input {
+	right: 6px
+}
+.colorpicker_field {
+	height: 22px;
+	width: 62px;
+	background-position: top;
+	position: absolute
+}
+.colorpicker_field span {
+	position: absolute;
+	width: 12px;
+	height: 22px;
+	overflow: hidden;
+	top: 0;
+	right: 0;
+	cursor: n-resize
+}
+.colorpicker_rgb_r {
+	background-image: url(../images/colorPicker/colorpicker_rgb_r.png);
+	top: 52px;
+	left: 212px
+}
+.colorpicker_rgb_g {
+	background-image: url(../images/colorPicker/colorpicker_rgb_g.png);
+	top: 82px;
+	left: 212px
+}
+.colorpicker_rgb_b {
+	background-image: url(../images/colorPicker/colorpicker_rgb_b.png);
+	top: 112px;
+	left: 212px
+}
+.colorpicker_hsb_h {
+	background-image: url(../images/colorPicker/colorpicker_hsb_h.png);
+	top: 52px;
+	left: 282px
+}
+.colorpicker_hsb_s {
+	background-image: url(../images/colorPicker/colorpicker_hsb_s.png);
+	top: 82px;
+	left: 282px
+}
+.colorpicker_hsb_b {
+	background-image: url(../images/colorPicker/colorpicker_hsb_b.png);
+	top: 112px;
+	left: 282px
+}
+.colorpicker_submit {
+	position: absolute;
+	width: 22px;
+	height: 22px;
+	background: url(../images/colorPicker/colorpicker_submit.png) top;
+	left: 322px;
+	top: 142px;
+	overflow: hidden
+}
+.colorpicker_focus {
+	background-position: center
+}
+.colorpicker_hex.colorpicker_focus {
+	background-position: bottom
+}
+.colorpicker_submit.colorpicker_focus {
+	background-position: bottom
+}
+.colorpicker_slider {
+	background-position: bottom
+}
+#colorSelector {
+	position: relative;
+	width: 36px;
+	height: 36px;
+	background: url(../images/colorPicker/select.png)
+}
+#colorSelector div {
+	position: absolute;
+	top: 3px;
+	left: 3px;
+	width: 30px;
+	height: 30px;
+	background: url(../images/colorPicker/select.png) center
+}
+#colorSelector2 {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 36px;
+	height: 36px;
+	background: url(../images/colorPicker/select2.png)
+}
+#colorSelector2 div {
+	position: absolute;
+	top: 4px;
+	left: 4px;
+	width: 28px;
+	height: 28px;
+	background: url(../images/colorPicker/select2.png) center
+}
+#colorpickerHolder2 {
+	top: 32px;
+	left: 0;
+	width: 356px;
+	height: 0;
+	overflow: hidden;
+	position: absolute
+}
+#colorpickerHolder2 .colorpicker {
+	background-image: url(../images/colorPicker/custom_background.png);
+	position: absolute;
+	bottom: 0;
+	left: 0
+}
+#colorpickerHolder2 .colorpicker_hue div {
+	background-image: url(../images/colorPicker/custom_indic.gif)
+}
+#colorpickerHolder2 .colorpicker_hex {
+	background-image: url(../images/colorPicker/custom_hex.png)
+}
+#colorpickerHolder2 .colorpicker_rgb_r {
+	background-image: url(../images/colorPicker/custom_rgb_r.png)
+}
+#colorpickerHolder2 .colorpicker_rgb_g {
+	background-image: url(../images/colorPicker/custom_rgb_g.png)
+}
+#colorpickerHolder2 .colorpicker_rgb_b {
+	background-image: url(../images/colorPicker/custom_rgb_b.png)
+}
+#colorpickerHolder2 .colorpicker_hsb_s {
+	background-image: url(../images/colorPicker/custom_hsb_s.png);
+	display: none
+}
+#colorpickerHolder2 .colorpicker_hsb_h {
+	background-image: url(../images/colorPicker/custom_hsb_h.png);
+	display: none
+}
+#colorpickerHolder2 .colorpicker_hsb_b {
+	background-image: url(../images/colorPicker/custom_hsb_b.png);
+	display: none
+}
+#colorpickerHolder2 .colorpicker_submit {
+	background-image: url(../images/colorPicker/custom_submit.png)
+}
+#colorpickerHolder2 .colorpicker input {
+	color: #778398
+}
+#customWidget {
+	position: relative;
+	height: 36px
+}
+#popup_container {
+	min-width: 300px;
+	max-width: 600px;
+	background: url(../images/alertOpacityOverlay.png) repeat;
+	-moz-border-radius: 5px;
+	-webkit-border-radius: 5px;
+	border-radius: 5px;
+	max-height: 70%;
+	top: 0;
+	overflow: scroll
+}
+#popup_title {
+	text-align: center;
+	background: url(../images/leftNavBg.png) repeat-x;
+	border-bottom: 1px solid #d5d5d5;
+	cursor: default;
+	padding: 9px 0 9px 0;
+	margin: 0;
+	height: 20px
+}
+#popup_content {
+	background: #fafafa;
+	padding: 1em 1.75em;
+	margin: 0
+}
+#popup_message {
+	text-align: center
+}
+#popup_panel {
+	text-align: center;
+	margin: 1em 0 0 0
+}
+#popup_message input[type=text] {
+	background: #fcfcfc;
+	border: 1px solid #d1d1d1;
+	padding: 5px;
+	width: 258px
+}
+#popup_prompt {
+	margin: .5em 0
+}
+#suspend_popup {
+	min-width: 300px;
+	max-width: 600px;
+	background: url(../images/alertOpacityOverlay.png) repeat;
+	-moz-border-radius: 5px;
+	-webkit-border-radius: 5px;
+	border-radius: 5px;
+	max-height: 101%;
+	top: 0
+}
+#suspend_popup_title {
+	text-align: center;
+	background: url(../images/leftNavBg.png) repeat-x;
+	border-bottom: 1px solid #d5d5d5;
+	cursor: default;
+	padding: 9px 0 9px 0;
+	margin: 0;
+	height: 20px
+}
+#suspend_popup_content {
+	background: #fafafa;
+	padding: 1em 1.75em;
+	margin: 0
+}
+#suspend_popup_message {
+	text-align: center
+}
+#suspend_popup_message .item {
+	text-align: left
+}
+#suspend_popup_message .item input {
+	width: auto
+}
+#suspend_popup_panel {
+	text-align: center;
+	margin: 1em 0 0 0
+}
+#suspend_popup_prompt {
+	margin: .5em 0
+}
+#suspend_popup_panel #popup_cancel,
+#suspend_popup_panel #popup_ok {
+	width: auto
+}
+#help_popup {
+	min-width: 300px;
+	max-width: 600px;
+    background: #547fa9;
+	-moz-border-radius: 5px;
+	-webkit-border-radius: 5px;
+	border-radius: 5px;
+	max-height: 101%;
+	top: 0
+}
+#help_popup_title {
+	text-align: center;
+	background: #fff;
+	border-bottom: 1px solid #d5d5d5;
+	cursor: default;
+	padding: 9px 0 9px 0;
+	margin: 0;
+	height: 20px
+}
+#help_popup_content {
+	background: #fafafa;
+	padding: 1em 0em;
+	margin: 0
+}
+#help_popup_message {
+	text-align: center
+}
+#help_popup_message .item {
+	text-align: left
+}
+#help_popup_message .item input {
+	width: auto
+}
+#help_popup_panel {
+	text-align: center;
+	margin: 1em 0 0 0
+}
+#help_popup_prompt {
+	margin: .5em 0
+}
+#help_popup_panel #popup_cancel,
+#help_popup_panel #popup_ok {
+	width: auto
+}
+.errorPage {
+	width: 370px;
+	margin: 100px auto 80px auto;
+	position: relative
+}
+.errorPage .errorTitle,
+.weAreOff {
+	background: url(../images/linesSep.png) repeat-x 0 100%;
+	width: 290px;
+	padding-bottom: 15px
+}
+.weAreOff {
+	width: 100%
+}
+.errorPage h1 {
+	color: #404040;
+	font-size: 140px;
+	margin: 80px 0;
+	position: relative;
+	padding-left: 10px
+}
+.errorPage h2 {
+	font-size: 22px;
+	font-weight: 400
+}
+.errorPage h2 span {
+	background: url(../images/sadEmo.png) no-repeat 0;
+	padding-left: 26px
+}
+.errorPage .bubbles {
+	position: absolute;
+	background: url(../images/error.png) no-repeat 0 0;
+	width: 138px;
+	height: 133px;
+	top: -10px;
+	left: 225px
+}
+.errorPage p {
+	width: 100%;
+	padding: 13px 0;
+	background: url(../images/linesSep.png) repeat-x 0 0;
+	font-size: 20px;
+	text-align: center
+}
+.backToDash {
+	text-align: center;
+	margin: 10px
+}
+.plupload_button {
+	font-size: 10px;
+	font-weight: 700;
+	text-transform: uppercase;
+	color: #fff;
+	line-height: 12px;
+	margin-top: 3px
+}
+.plupload_start {
+	float: left;
+	background: url(../images/ui/greenBtn.png) repeat-x 0 0;
+	border: 1px solid #418d4f
+}
+.plupload_start span {
+	background: url(../images/upload.png) no-repeat 10px;
+	padding: 5px 13px 6px 26px;
+	display: block
+}
+.plupload_start:hover {
+	background-position: 0 -25px
+}
+.plupload_start:active {
+	background-position: 0 -50px
+}
+.plupload_disabled,
+a.plupload_disabled:hover {
+	color: #a6a6a6;
+	border: 1px solid #e9e9e9;
+	background: url(../images/ui/uploadDisabled.png) repeat-x;
+	cursor: default
+}
+.plupload_disabled span {
+	padding: 5px 13px 6px 13px
+}
+.plupload_add {
+	margin-right: 10px;
+	background: url(../images/ui/greyishBtn.png) repeat-x 0 0;
+	border: 1px solid #4f5a68;
+	float: left
+}
+.plupload_add span {
+	background: url(../images/add.png) no-repeat 10px;
+	padding: 5px 13px 6px 26px;
+	display: block
+}
+.plupload_add:hover {
+	background-position: 0 -25px
+}
+.plupload_add:active {
+	background-position: 0 -50px
+}
+.plupload_wrapper {
+	font-size: 11px;
+	width: 100%
+}
+.plupload_container input {
+	border: 1px solid #ddd;
+	font-size: 11px;
+	width: 98%
+}
+.plupload_filelist {
+	margin: 0;
+	padding: 0;
+	list-style: none
+}
+.plupload_scroll .plupload_filelist {
+	height: 185px;
+	background: #fafafa;
+	overflow-y: scroll
+}
+.plupload_filelist li {
+	padding: 10px 12px;
+	background: #f5f5f5;
+	border-bottom: 1px solid #e7e7e7
+}
+.plupload_filelist li:hover {
+	background: #fdfdfd
+}
+.plupload_filelist_footer,
+.plupload_filelist_header {
+	background: #efefef url(../images/leftNavBg.png) repeat-x;
+	padding: 3px 12px;
+	color: #878787
+}
+.plupload_filelist_header {
+	border-bottom: 1px solid #d5d5d5
+}
+.plupload_filelist_footer {
+	border-top: 1px solid #d5d5d5;
+	height: 31px;
+	line-height: 30px;
+	vertical-align: middle
+}
+.plupload_file_name {
+	float: left;
+	overflow: hidden
+}
+.plupload_file_status {
+	color: #777
+}
+.plupload_file_size,
+.plupload_file_status,
+.plupload_progress {
+	float: right;
+	width: 80px
+}
+.plupload_file_action,
+.plupload_file_size,
+.plupload_file_status {
+	text-align: right
+}
+.plupload_filelist .plupload_file_name {
+	width: 205px
+}
+.plupload_file_action {
+	float: right;
+	width: 14px;
+	margin-top: 3px;
+	height: 14px;
+	margin-left: 15px
+}
+.plupload_file_action * {
+	display: none;
+	width: 14px;
+	height: 14px
+}
+li.plupload_done {
+	color: #aaa
+}
+li.plupload_delete a {
+	background: url(../images/uploader/deleteFile.png) no-repeat 0
+}
+li.plupload_failed a {
+	background: url(../images/uploader/error.png) no-repeat 0;
+	cursor: default
+}
+li.plupload_done a {
+	background: url(../images/uploader/uploaded.png) no-repeat 0;
+	cursor: default
+}
+.plupload_progress,
+.plupload_upload_status {
+	display: none
+}
+.plupload_progress_container {
+	margin-top: 10px;
+	border: 1px solid #ccc;
+	background: #fff;
+	padding: 1px
+}
+.plupload_progress_bar {
+	width: 0;
+	height: 7px;
+	background: #cdeb8b
+}
+.plupload_scroll .plupload_filelist_footer .plupload_file_action,
+.plupload_scroll .plupload_filelist_header .plupload_file_action {
+	margin-right: 17px
+}
+.plupload_clear,
+.plupload_clearer {
+	clear: both
+}
+.plupload_clearer,
+.plupload_progress_bar {
+	display: block;
+	font-size: 0;
+	line-height: 0
+}
+li.plupload_droptext {
+	background: 0 0;
+	text-align: center;
+	vertical-align: middle;
+	border: 0;
+	line-height: 165px
+}
+.swMain {
+	position: relative
+}
+.swMain .stepContainer {
+	display: block;
+	position: relative;
+	overflow: hidden;
+	clear: both
+}
+.swMain .stepContainer div.wContent {
+	display: block;
+	position: absolute;
+	float: left;
+	margin: 0;
+	text-align: left;
+	overflow: visible;
+	z-index: 88;
+	clear: both;
+	width: 100%
+}
+.swMain .stepContainer div.wContent p {
+	padding: 12px
+}
+.swMain div.actionBar {
+	display: block;
+	position: relative;
+	clear: both;
+	padding: 0;
+	color: #5a5655;
+	height: 41px;
+	text-align: left;
+	overflow: auto;
+	z-index: 88;
+	left: 0;
+	background: #efefef url(../images/leftNavBg.png) repeat-x;
+	border-top: 1px solid #d5d5d5
+}
+.actionBar a.button {
+	box-shadow: none
+}
+.swMain .stepContainer .StepTitle {
+	display: block;
+	position: relative;
+	margin: 0;
+	border: 1px solid #e0e0e0;
+	padding: 5px;
+	color: #5a5655;
+	clear: both;
+	text-align: left;
+	z-index: 88
+}
+.swMain ul.anchor {
+	position: relative;
+	display: block;
+	float: left;
+	list-style: none;
+	padding: 0;
+	clear: both;
+	border-top: 1px solid #d5d5d5;
+	border-bottom: 1px solid #d5d5d5;
+	width: 100%
+}
+.swMain ul.anchor li {
+	position: relative;
+	display: block;
+	margin: 0;
+	padding: 0;
+	float: left;
+	width: 25%
+}
+.swMain ul.anchor li:first-child {
+	border-left: none
+}
+.swMain ul.anchor li a {
+	display: block;
+	position: relative;
+	float: left;
+	margin: 0;
+	height: 38px;
+	width: 100%;
+	text-decoration: none;
+	outline-style: none;
+	z-index: 99;
+	cursor: pointer;
+	background: url(../images/leftNavBg.png) repeat-x;
+	border-left: 1px solid #d5d5d5
+}
+.swMain ul.anchor li:first-child a {
+	border-left: none
+}
+.swMain ul.anchor li a .stepNumber {
+	position: relative;
+	float: left;
+	width: 30px;
+	text-align: center;
+	padding: 5px;
+	padding-top: 0
+}
+.swMain ul.anchor li a .stepDesc {
+	position: relative;
+	display: block;
+	float: left;
+	text-align: left;
+	padding: 8px 12px 8px 35px;
+	white-space: nowrap
+}
+.swMain ul.anchor li a.selected {
+	color: #3581c1;
+	background: #fafafa
+}
+.swMain ul.anchor li a.done {
+	position: relative;
+	color: #aaa;
+	z-index: 99;
+	background: #efefef
+}
+.swMain ul.anchor li a.done:hover {
+	color: #5a5655
+}
+.swMain ul.anchor li a.disabled {
+	color: #424242;
+	cursor: text
+}
+.swMain ul.anchor li a.error {
+	color: #6c6c6c!important;
+	border: 1px solid #fb3500!important
+}
+.swMain ul.anchor li a.error:hover {
+	color: #000!important
+}
+.swMain .buttonNext {
+	display: block;
+	float: right;
+	margin: 8px 12px 0 12px;
+	padding: 6px 12px
+}
+.swMain .buttonDisabled {
+	color: #d5d5d5!important;
+	cursor: text;
+	background: #f1f1f1!important;
+	margin-top: 8px!important;
+	border: 1px solid #e1e1e1
+}
+.swMain .buttonPrevious {
+	display: block;
+	float: right;
+	margin: 8px 0 0 0;
+	padding: 6px 12px
+}
+.swMain .buttonFinish {
+	display: block;
+	float: right;
+	margin: 8px 12px 0 0;
+	padding: 6px 12px
+}
+.swMain .loader {
+	position: relative;
+	display: none;
+	float: left;
+	margin: 2px 0 0 2px;
+	padding: 8px 10px 8px 40px;
+	border: 1px solid gold;
+	color: #5a5655;
+	background: url(../images/loaders/loader.gif) no-repeat 5px;
+	z-index: 998
+}
+.swMain .msgBox {
+	position: relative;
+	display: none;
+	float: left;
+	margin: 4px 0 0 5px;
+	padding: 5px;
+	border: 1px solid gold;
+	background-color: #ffd;
+	color: #5a5655;
+	z-index: 999;
+	min-width: 200px
+}
+.swMain .msgBox .content {
+	padding: 0;
+	float: left
+}
+.swMain .msgBox .close {
+	border: 1px solid #d5d5d5;
+	color: #ccc;
+	display: block;
+	float: right;
+	margin: 0 0 0 5px;
+	outline-style: none;
+	padding: 0 2px 0 2px;
+	position: relative;
+	text-align: center;
+	text-decoration: none
+}
+.swMain .msgBox .close:hover {
+	color: #ea8511;
+	border: 1px solid #d5d5d5
+}
+.bordLeft {
+	border-top-left-radius: 3px;
+	-moz-border-radius-topleft: 3px;
+	-webkit-border-top-left-radius: 3px
+}
+.bordRight {
+	border-top-right-radius: 3px;
+	-moz-border-radius-topright: 3px;
+	-webkit-border-top-right-radius: 3px
+}
+.contentHead {
+	padding: 16px 12px 15px 35px
+}
+.timepicker {
+	width: 60px!important
+}
+.timeEntry_control {
+	vertical-align: middle;
+	margin-left: -1px;
+	margin-top: -2px;
+	cursor: pointer
+}
+* html .timeEntry_control {
+	margin-top: -4px
+}
+.dualBoxes {
+	padding: 22px 16px;
+	position: relative
+}
+.dualBtn {
+	padding: 6px 8px;
+	cursor: pointer;
+	line-height: 12px;
+	background: url(../images/ui/basicBtn.png) repeat-x 0 0;
+	border: 1px solid #d5d5d5;
+	color: #525252;
+	margin-left: -1px
+}
+.dualBtn:hover {
+	background-position: 0 -25px;
+	border-color: #c9c9c9
+}
+.dualBtn:active {
+	background-position: 0 -50px
+}
+.fltr {
+	position: absolute;
+	right: 0
+}
+.boxFilter {
+	margin-bottom: 15px
+}
+.dualControl {
+	text-align: center;
+	width: 90px;
+	margin: 150px 1px;
+	position: absolute;
+	left: 50%;
+	margin-left: -45px
+}
+.countLabel {
+	color: gray;
+	font-style: italic;
+	margin-top: 10px;
+	display: block
+}
+.storageBox {
+	display: none
+}
+.copiedOption {
+	background-color: #ff0
+}
+.feat {
+	margin-left: 5px;
+	background: url(../images/forms/fileUpload.png) no-repeat 0 0;
+	width: 94px;
+	height: 26px
+}
+.feat:hover {
+	background-position: 0 -27px
+}
+.feat:active {
+	background-position: 0 -54px
+}
+.fileInput {
+	background: #fff;
+	border: 1px solid #d5d5d5;
+	padding: 5px;
+	font-size: 11px;
+	font-family: Arial, Helvetica, sans-serif
+}
+.fileInput:hover {
+	background: #fcfcfc;
+	border: 1px solid #d1d1d1
+}
+.fileInput:focus {
+	border: 1px solid #bbc1c9;
+	background: #fff
+}
+.step {
+	position: relative
+}
+.step label.error {
+	color: #b84646;
+	padding-left: 0;
+	font-size: 11px;
+	white-space: nowrap;
+	padding-bottom: 0
+}
+.selector .error {
+	position: absolute;
+	right: -114px
+}
+.step h5 {
+	position: absolute;
+	left: 12px;
+	top: -30px
+}
+.wizNav {
+	padding: 14px 16px;
+	border-top: 1px solid #e7e7e7;
+	text-align: right
+}
+.wizNav input {
+	margin-left: 10px
+}
+.wizNav input[disabled] {
+	background: #fcfcfc;
+	border: 1px solid #eaeaea;
+	color: #d5d5d5
+}
+.chzn-container {
+	position: relative;
+	display: inline-block;
+	zoom: 1
+}
+.noSearch .chzn-search,
+.noSearch .selector,
+.searchDrop .selector {
+	display: none
+}
+.formRight .chzn-container-multi {
+	width: 100%!important
+}
+.noSearch .chzn-results {
+	margin: 0!important;
+	padding: 2px!important
+}
+.chzn-container>.chzn-drop {
+	background: #fff;
+	border: 1px solid #d5d5d5;
+	border-top: 0;
+	position: absolute;
+	top: 29px;
+	margin-top: 1px;
+	left: 0;
+	z-index: 998;
+	width: 100%!important;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-ms-box-sizing: border-box;
+	box-sizing: border-box
+}
+.chzn-container-single .chzn-single {
+	background: url(../images/chosenSelect.png) repeat-x;
+	border: 1px solid #d8d8d8;
+	display: block;
+	overflow: hidden;
+	white-space: nowrap;
+	position: relative;
+	height: 26px;
+	line-height: 27px;
+	padding: 0 0 0 8px;
+	color: #595959;
+	text-decoration: none
+}
+.chzn-container-single .chzn-single span {
+	margin-right: 26px;
+	display: block;
+	font-size: 11px;
+	overflow: hidden;
+	white-space: nowrap;
+	-o-text-overflow: ellipsis;
+	-ms-text-overflow: ellipsis;
+	text-overflow: ellipsis
+}
+.chzn-container-single .chzn-single abbr {
+	display: block;
+	position: absolute;
+	right: 26px;
+	top: 6px;
+	width: 12px;
+	height: 13px;
+	font-size: 1px
+}
+.chzn-container-single .chzn-single div {
+	position: absolute;
+	right: -1px;
+	top: -1px;
+	display: block;
+	height: 28px;
+	width: 27px
+}
+.chzn-container-single .chzn-single div b {
+	background: url(../images/forms/select_right.png) no-repeat center right;
+	display: block;
+	width: 27px;
+	height: 28px
+}
+.chzn-container-single .chzn-search {
+	padding: 3px 4px;
+	position: relative;
+	margin: 0;
+	white-space: nowrap;
+	z-index: 1010
+}
+.chzn-container-single .chzn-search input {
+	margin: 1px 0;
+	padding: 4px 20px 4px 5px;
+	outline: 0;
+	border: 1px solid #aaa;
+	font-family: sans-serif;
+	font-size: 11px;
+	background: url(../images/searchSmall.png) no-repeat 98%!important;
+	box-sizing: content-box;
+	-webkit-box-sizing: content-box;
+	-moz-box-sizing: content-box;
+	-ms-box-sizing: content-box
+}
+.chzn-container-single-nosearch .chzn-search input {
+	position: absolute;
+	left: -9000px
+}
+.chzn-container-multi .chzn-choices {
+	border: 1px solid #ddd;
+	margin: 0;
+	cursor: text;
+	overflow: hidden;
+	height: auto!important;
+	height: 1%;
+	position: relative;
+	font-size: 12px;
+	padding: 4px;
+	background: #fff;
+	color: #656565
+}
+.chzn-container-multi .chzn-choices li {
+	float: left;
+	list-style: none
+}
+.chzn-container-multi .chzn-choices .search-field {
+	white-space: nowrap;
+	margin: 0;
+	padding: 0
+}
+.chzn-container-multi .chzn-choices .search-field input {
+	color: #666;
+	background: 0 0!important;
+	border: 0!important;
+	font-family: sans-serif;
+	font-size: 12px!important;
+	padding: 11px 4px 10px 4px!important;
+	margin: 0;
+	outline: 0;
+	box-shadow: none!important
+}
+.chzn-container-multi .chzn-choices .search-field .default {
+	color: #999
+}
+.chzn-container-multi .chzn-choices .search-choice {
+	position: relative;
+	line-height: 16px;
+	font-size: 11px;
+	border: 1px solid #a5d24a;
+	display: block;
+	float: left;
+	padding: 5px 24px 5px 8px;
+	background: #cde69c;
+	color: #638421;
+	margin: 4px
+}
+.chzn-container-multi .chzn-choices .search-choice-focus {
+	background: #d4d4d4
+}
+.chzn-container-multi .chzn-choices .search-choice .search-choice-close {
+	display: block;
+	position: absolute;
+	right: 6px;
+	top: 8px;
+	width: 10px;
+	height: 10px;
+	font-size: 1px;
+	background: url(../images/icons/closeSelection.png) 50% no-repeat
+}
+.chzn-container-multi .chzn-choices .search-choice-focus .search-choice-close {
+	background-position: right -11px
+}
+.chzn-container .chzn-results {
+	margin: 0 4px 4px 0;
+	max-height: 240px;
+	padding: 0 0 0 4px;
+	position: relative;
+	overflow-x: hidden;
+	overflow-y: auto
+}
+.chzn-container-multi .chzn-results {
+	padding: 0;
+	margin: 0
+}
+.chzn-container .chzn-results li {
+	display: none;
+	line-height: 14px;
+	padding: 5px 6px;
+	margin: 0;
+	list-style: none;
+	font-size: 11px
+}
+.chzn-container .chzn-results .active-result {
+	cursor: pointer;
+	display: list-item
+}
+.chzn-container .chzn-results .highlighted {
+	background-color: #3875d7;
+	color: #fff
+}
+.chzn-container .chzn-results li em {
+	background: #feffde;
+	font-style: normal
+}
+.chzn-container .chzn-results .highlighted em {
+	background: 0 0
+}
+.chzn-container .chzn-results .no-results {
+	background: #f4f4f4;
+	display: list-item
+}
+.chzn-container .chzn-results .group-result {
+	cursor: default;
+	color: #2e74a6;
+	font-weight: 700;
+	font-size: 10px;
+	border-bottom: 1px solid #ddd;
+	border-top: 1px solid #ddd
+}
+.chzn-container .chzn-results .group-option {
+	padding-left: 15px
+}
+.chzn-container-multi .chzn-drop .result-selected {
+	display: none
+}
+.chzn-container .chzn-results-scroll {
+	background: #fff;
+	margin: 0 4px;
+	position: absolute;
+	text-align: center;
+	width: 321px;
+	z-index: 1
+}
+.chzn-container .chzn-results-scroll span {
+	display: inline-block;
+	height: 17px;
+	text-indent: -5000px;
+	width: 9px
+}
+.chzn-container .chzn-results-scroll-down {
+	bottom: 0
+}
+.chzn-container-active .chzn-single-with-drop div {
+	background: 0 0;
+	border-left: none
+}
+.chzn-container-active .chzn-choices {
+	border: 1px solid #d5d5d5
+}
+.chzn-container-active .chzn-choices .search-field input {
+	color: #111!important
+}
+.chzn-disabled {
+	cursor: default;
+	opacity: .5!important
+}
+.chzn-disabled .chzn-single {
+	cursor: default
+}
+.chzn-disabled .chzn-choices .search-choice .search-choice-close {
+	cursor: default
+}
+@media only screen and (max-width: 799px) {
+	.leftNav {
+		float: none;
+		background: url(../images/linesSep.png) repeat-x;
+		padding-top: 24px;
+		text-align: center;
+		padding-bottom: 20px;
+		margin: 0;
+		width: 100%;
+		max-width: none
+	}
+	.leftNav ul li {
+		width: 49px;
+		display: inline-block;
+		margin: 0 0 4px 0;
+		position: static
+	}
+	.leftNav ul li a span {
+		text-indent: -9999px;
+		background-position: 16px
+	}
+	.leftNav ul li a {
+		margin-bottom: 3px
+	}
+	.numberLeft {
+		display: none!important
+	}
+	.widgets .left {
+		float: none;
+		width: 100%;
+		margin-right: 0
+	}
+	.widgets .right {
+		float: none;
+		width: 100%
+	}
+	#header {
+		text-align: center;
+		height: 100%;
+		margin-bottom: 22px
+	}
+	ul.sub {
+		position: absolute;
+		width: 100%;
+		left: 0;
+		z-index: 999;
+		border: 1px solid #d5d5d5;
+		border-bottom: 0
+	}
+	ul.sub li {
+		display: block;
+		width: 50%;
+		float: left;
+		margin-bottom: 0;
+		text-align: left;
+		border-bottom: 1px solid #d5d5d5;
+		padding: 0
+	}
+	ul.sub li a {
+		padding: 8px 10px 8px 24px;
+		background: url(../images/arrow.gif) no-repeat 12px 16px
+	}
+	.sub li a:active,
+	ul.sub li a:hover {
+		background-position: 12px 16px
+	}
+	ul.sub li:nth-child(odd) {
+		background: url(../images/tabsSepR.png) repeat-y 100% 0
+	}
+	ul#menu {
+		position: relative
+	}
+	.leftNav .last {
+		border-bottom: 1px solid #d5d5d5
+	}
+}
+@media only screen and (max-width: 767px) {
+	.stats ul li {
+		display: inline-block;
+		float: none;
+		margin-left: 18px;
+		vertical-align: top;
+		width: 21%;
+		text-align: center
+	}
+	.stats ul {
+		text-align: center
+	}
+	.count {
+		display: inline-block;
+		float: none;
+		padding: 0 15px;
+		text-align: center;
+		margin-bottom: 4px;
+		margin-right: 0
+	}
+	.middleNav {
+		float: none;
+		margin-right: 0;
+		display: block;
+		text-align: center;
+		margin-top: 2px
+	}
+	.middleNav ul li {
+		text-align: center;
+		display: inline-block;
+		float: none;
+		margin-left: 5%;
+		position: relative
+	}
+	.middleNav ul li:first-child {
+		margin-left: 0
+	}
+	.logo {
+		float: none
+	}
+	.userNav ul li span {
+		display: none
+	}
+	.userNav ul li img {
+		padding: 13px 14px 11px 14px;
+		margin: 0
+	}
+	.userNav ul li ul {
+		right: -3px;
+		left: auto
+	}
+	.listData .cNote {
+		display: none
+	}
+	ul.listData li {
+		padding: 0 0 1px 6px!important
+	}
+	.rowElem>label {
+		width: 100%;
+		float: none;
+		padding: 8px 0 6px 0
+	}
+	.formRight {
+		width: 100%;
+		margin: 0;
+		padding: 12px 0;
+		float: none
+	}
+	.rowElem .topLabel {
+		padding: 5px 12px 5px 0
+	}
+	.fc-header-right {
+		width: 50%
+	}
+	.ln-letters a {
+		padding: 4px 2%;
+		margin-bottom: 1px
+	}
+	#eq span {
+		margin-right: 0;
+		margin-left: 30px
+	}
+	#eq span:first-child {
+		margin-left: 5px
+	}
+	.formError {
+		left: auto!important;
+		right: 30px
+	}
+	.formErrorContent {
+		width: 140px
+	}
+	.formRight div.checker,
+	.formRight div.radio {
+		padding-bottom: 0;
+		padding-top: 0;
+		margin-top: 2px
+	}
+	div.selector {
+		margin-bottom: 10px
+	}
+	.formRight>label {
+		padding-top: 0
+	}
+	.rowElem>label {
+		padding-bottom: 0
+	}
+	.step label.error {
+		padding-top: 3px
+	}
+	.userWidget .checker {
+		margin-top: 6px
+	}
+}
+@media only screen and (min-width: 800px) and (max-width: 979px) {
+	.leftNav {
+		width: 24%
+	}
+}
+@media only screen and (min-width: 320px) and (max-width: 479px) {
+	.logo {
+		float: none;
+		text-align: center
+	}
+	.welcome {
+		display: none
+	}
+	.userNav {
+		float: none;
+		text-align: center;
+		position: relative
+	}
+	.userNav ul {
+		height: 36px;
+		text-align: center
+	}
+	.userNav>ul>li {
+		display: inline-block;
+		float: none;
+		position: static;
+		margin-left: -3px
+	}
+	.userNav ul li ul {
+		height: auto;
+		text-align: left;
+		position: absolute;
+		top: 36px;
+		left: 50%;
+		margin-left: -85px;
+		width: 162px
+	}
+	.middleNav ul {
+		text-align: center
+	}
+	.middleNav ul li {
+		text-align: center;
+		display: inline-block;
+		float: none;
+		margin: 0 2%;
+		position: relative;
+		width: 45%;
+		margin-bottom: 10px
+	}
+	.middleNav ul li:first-child {
+		margin: 0 2%
+	}
+	.stats ul {
+		text-align: center
+	}
+	.stats ul li {
+		display: inline-block;
+		float: none;
+		margin: 5px;
+		vertical-align: top;
+		width: 46%;
+		text-align: center
+	}
+	.stats ul li:first-child {
+		margin: 5px
+	}
+	.count {
+		display: inline-block;
+		float: none;
+		padding: 0 15px;
+		text-align: center;
+		margin-bottom: 4px;
+		margin-right: 0;
+		width: 75%
+	}
+	.w40 {
+		width: auto
+	}
+	.floatleft,
+	.floatright {
+		float: none
+	}
+	.floatright {
+		margin-top: 95px
+	}
+	.countLabel {
+		text-align: center
+	}
+	.dualControl {
+		text-align: center;
+		width: 90px;
+		margin: 10px 1px;
+		position: absolute;
+		left: 50%;
+		margin-left: -45px
+	}
+	.moreFields ul li {
+		width: 11.8%
+	}
+	.moreFields ul li span {
+		display: none
+	}
+	#header {
+		margin-bottom: 15px
+	}
+	.checker,
+	.radio {
+		clear: both
+	}
+	.plupload_file_size,
+	.plupload_file_status,
+	.plupload_progress {
+		width: 12%
+	}
+	.plupload_disabled span {
+		padding: 5px 8px 6px 8px
+	}
+	.plupload_add span {
+		background: url(../images/add.png) no-repeat 10px;
+		padding: 5px 8px 6px 20px;
+		display: block
+	}
+	.fc-header-right {
+		width: auto
+	}
+	.dataTables_filter input[type=text] {
+		width: 86px
+	}
+	.dataTables_paginate {
+		float: left
+	}
+	.dataTables_paginate .ui-buttonset .ui-button {
+		margin: 0 1px
+	}
+	.issueSummary .floatleft {
+		display: none
+	}
+	.ticketInfo {
+		margin-left: 0
+	}
+	.breadCrumb {
+		overflow: hidden;
+		height: 100%
+	}
+	.pages li {
+		display: inline-block;
+		margin: 4px 2px
+	}
+	#popup_container {
+		min-width: 250px;
+		max-width: 300px
+	}
+	.el-finder-nav {
+		width: 100px
+	}
+	.errorPage {
+		width: auto
+	}
+	.errorPage .bubbles {
+		display: none
+	}
+	.errorPage .errorTitle,
+	.weAreOff {
+		width: auto
+	}
+	.errorPage h1 {
+		padding: 0;
+		text-align: center
+	}
+	#myList>li {
+		clear: both
+	}
+	ul.listData {
+		float: left;
+		text-align: center;
+		margin: 3px 0 5px 0;
+		font-size: 11px
+	}
+	ul.listData li {
+		padding: 0;
+		margin: 0 20px 0 -6px;
+		clear: both
+	}
+	.displayNone {
+		display: none
+	}
+	.pieWidget {
+		width: 100%;
+		height: 250px;
+		margin: 0 auto
+	}
+	.paging_full_numbers .ui-button {
+		padding: 2px 5px
+	}
+	table.display {
+		table-layout: fixed
+	}
+	table.display thead th div.DataTables_sort_wrapper {
+		overflow: hidden;
+		padding-right: 10px
+	}
+	table.display thead th div.DataTables_sort_wrapper span {
+		display: none
+	}
+	table.display td {
+		overflow: hidden
+	}
+	.dataTables_length {
+		float: none;
+		margin: 6px auto 0 auto;
+		width: 140px
+	}
+	.dataTables_paginate {
+		float: none;
+		width: 253px;
+		display: inline-block;
+		text-align: center;
+		margin-top: 2px
+	}
+	.chzn-container {
+		width: 254px!important
+	}
+	.chzn-container-single .chzn-search input {
+		max-width: 218px
+	}
+}
+@media only screen and (min-width: 480px) and (max-width: 767px) {
+	.moreFields ul li {
+		width: 13.4%
+	}
+	.moreFields ul li span {
+		display: none
+	}
+}
+.moreFields div.radio span {
+	padding: 0
+}
+.truncate {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis
+}
+.dark-sprite-icon {
+	margin-right: 10px;
+	display: inline-block;
+	background-repeat: no-repeat
+}
+.sprite-topnav {
+	background-repeat: no-repeat;
+	display: inline-block
+}
+.sprite-23 {
+	background-repeat: no-repeat;
+	display: block;
+	margin: 0 auto
+}
+.ajax-loader {
+	background: url(../images/loader.gif);
+	width: 16px;
+	height: 11px;
+	display: inline-block
+}
+
+.sidebar {
+  height: 100%;
+  width: 0;
+  position: fixed;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  background-color: #262b2f;
+  overflow-x: hidden;
+  transition: 0.5s;
+  padding-top: 60px;
+}
+
+.sidebar a {
+  padding: 8px 8px 8px 15px;
+  text-decoration: none;
+  font-size: 20px;
+  color: #818181;
+  display: block;
+  transition: 0.3s;
+}
+
+.sidebar a:hover {
+  color: #f1f1f1;
+}
+
+.sidebar .closebtn {
+  position: absolute;
+  right: 2px;
+  font-size: 36px;
+  margin-left: 50px;
+}
+
+.openbtn {
+  font-size: 20px;
+  cursor: pointer;
+  background-color: #262b2f;
+  color: white;
+  padding: 10px 15px;
+  border: none;
+}
+
+.openbtn:hover {
+  background-color: #444;
+}
+
+#main {
+  transition: margin-left .5s;
+  padding: 16px;
+}
+
+/* On smaller screens, where height is less than 450px, change the style of the sidenav (less padding and a smaller font size) */
+@media screen and (max-height: 450px) {
+  .sidebar {padding-top: 15px;}
+  .sidebar a {font-size: 18px;}
+}
+
+.nav-vertical-separator{
+    border-left: 2px solid rgb(255 255 255 / 71%);
+    height: 15px;
+    margin: 10px 2px 0px 2px;
+}

--- a/src/bb-themes/admin_default/html/layout_default.phtml
+++ b/src/bb-themes/admin_default/html/layout_default.phtml
@@ -24,35 +24,65 @@
 {% if not admin %}
 <script type="text/javascript">$(function(){bb.redirect("{{ 'staff/login'|alink }}");});</script>
 {% else %}
+<script>
+function openNav() {
+  document.getElementById("mySidebar").style.width = "250px";
+  document.getElementById("main").style.marginLeft = "250px";
+}
+
+function closeNav() {
+  document.getElementById("mySidebar").style.width = "0";
+  document.getElementById("main").style.marginLeft= "0";
+}
+</script>
 <div id="topNav">
     <div class="fixed">
         <div class="wrapper">
             <div class="welcome">
-                <a href="{{ 'staff/profile'|alink }}" title=""><img src="{{ profile.email|gravatar }}?size=20" alt="{{ profile.name }}" /></a><span>{% trans 'Hi,' %} {{ profile.name }}!</span>
-                {% set languages = guest.extension_languages %}
-                {% if languages|length > 1 %}
-                <span>
-                    <select name="lang" class="language_selector" style="background-color: #262b2f; color:white;">
-                        {% for lang in languages %}
-                        <option value="{{ lang }}" class="lang_{{ lang }}">{{ lang|trans }}</option>
-                        {% endfor %}
-                    </select>
-                </span>
-                {% endif %}
+				<button class="openbtn" onclick="openNav()">☰ </button>  
             </div>
             <div class="userNav">
                 <ul>
+                    <li>
+					<a href="{{ 'staff/profile'|alink }}" title=""><img src="{{ profile.email|gravatar }}?size=20" alt="{{ profile.name }}" /><span>{% trans 'Hi,' %} {{ profile.name }}!</a></span>
+					{% set languages = guest.extension_languages %}
+					{% if languages|length > 1 %}
+					<span>
+						<select name="lang" class="language_selector" style="background-color: #262b2f; color:white;">
+							{% for lang in languages %}
+							<option value="{{ lang }}" class="lang_{{ lang }}">{{ lang|trans }}</option>
+							{% endfor %}
+						</select>
+					</span>
+					{% endif %}
+                    </li>
+            <li class="nav-vertical-separator"></li>
+            {% if admin.system_is_allowed({"mod":"notification"}) and guest.extension_is_on({"mod":"notification"}) %}
+            {% set count_notifications = admin.notification_get_list({"per_page":1}).total %}
+        	<li class="iMegaphone"><a href="{{ 'notification'|alink }}" title=""><span>{% trans 'Notifications' %}</span></a>{% if count_notifications %}<span class="numberMiddle">{{ count_notifications }}</span>{% endif %}</li>
+            {% endif %}
+            
+            {% if admin.system_is_allowed({"mod":"order"}) %}
+            {% set count_orders = admin.order_get_statuses.failed_setup %}
+        	<li class="iOrders"><a href="{{ 'order'|alink({'status' : 'failed_setup'}) }}" title=""><span><i class="dark-sprite-icon sprite-basket2"></i></span></a>{% if count_orders %}<span class="numberMiddle">{{ count_orders }}</span>{% endif %}</li>
+            {% endif %}
+            
+            {% if admin.system_is_allowed({"mod":"invoice"}) %}
+            {% set count_invoices = admin.invoice_get_statuses.unpaid %}
+        	<li class="iInvoices"><a href="{{ 'invoice'|alink({'status' : 'unpaid'}) }}" title=""><span><i class="dark-sprite-icon sprite-money"></i></span></a>{% if count_invoices %}<span class="numberMiddle">{{ count_invoices }}</span>{% endif %}</li>
+            {% endif %}
+            
+            {% if admin.system_is_allowed({"mod":"support"}) %}
+            {% set count_tickets = admin.support_ticket_get_statuses.open %}
+        	<li class="iMes"><a href="{{ 'support'|alink({'status' : 'open'}) }}" title=""><span><i class="dark-sprite-icon sprite-dialog"></i></span></a>{% if count_tickets %}<span class="numberMiddle">{{ count_tickets }}</span>{% endif %}</li>
+            {% endif %}
+            <li class="nav-vertical-separator"></li>
                     <li class="loading" style="display:none;"><img src="images/loader.gif" alt="" /><span>{% trans 'Loading ...' %}</span></li>
                     <li class="dd"><span><i class="sprite-topnav sprite-topnav-register" style="margin-right: 5px;"></i>{% trans 'New' %}</span>
                         {% include "partial_menu_top.phtml" %}
                     </li>
                     {% if admin.system_is_allowed({"mod":"system"}) %}
-                    <li class="dd"><span><i class="sprite-topnav sprite-topnav-settings" style="margin-right: 5px;"></i>{% trans 'Settings' %}</span>
-                        <ul class="menu_body">
-                            <li><a href="{{ 'system'|alink }}" title="">{% trans 'All settings' %}</a></li>
-                            <li><a href="{{ 'theme'|alink }}/{{ guest.extension_theme.code }}" title="">{% trans 'Theme settings' %}</a></li>
-                        </ul>
-                    </li>
+                    <li><a href="{{ 'system'|alink }}" title=""><span><i class="sprite-topnav sprite-topnav-settings" style="margin-right: 5px;"></i>{% trans 'Settings' %}</span></a></li>
                     {% endif %}
                     <li><a href="{{ '/'|link }}" title="" target="_blank"><span><i class="sprite-topnav sprite-topnav-mainWebsite" style="margin-right: 5px;"></i>{% trans 'Visit site' %}</span></a></li>
                     <li><a href="{{ 'api/admin/profile/logout'|link }}" title="" class="api-link" data-api-redirect="{{ 'staff/login'|alink }}"><span><i class="sprite-topnav sprite-topnav-logout" style="margin-right: 5px;"></i>{% trans 'Logout' %}</span></a></li>
@@ -62,57 +92,27 @@
         </div>
     </div>
 </div>
-
 <div id="header" class="wrapper">
-    <div class="logo"><a href="{{ 'system'|alink }}" title=""><img src="{{ company.logo_url }}" alt="{{ company.name }}" style="max-height: 50px;"/></a></div>
-    <div class="middleNav">
-        
-    	<ul>
-            {% if admin.system_is_allowed({"mod":"notification"}) and guest.extension_is_on({"mod":"notification"}) %}
-            {% set count_notifications = admin.notification_get_list({"per_page":1}).total %}
-        	<li class="iMegaphone"><a href="{{ 'notification'|alink }}" title=""><span>{% trans 'Notifications' %}</span></a>{% if count_notifications %}<span class="numberMiddle">{{ count_notifications }}</span>{% endif %}</li>
-            {% endif %}
-            
-            {% if admin.system_is_allowed({"mod":"order"}) %}
-            {% set count_orders = admin.order_get_statuses.failed_setup %}
-        	<li class="iOrders"><a href="{{ 'order'|alink({'status' : 'failed_setup'}) }}" title=""><span><i class="sprite-23 sprite-23-basket2"></i>{% trans 'Orders' %}</span></a>{% if count_orders %}<span class="numberMiddle">{{ count_orders }}</span>{% endif %}</li>
-            {% endif %}
-            
-            {% if admin.system_is_allowed({"mod":"invoice"}) %}
-            {% set count_invoices = admin.invoice_get_statuses.unpaid %}
-        	<li class="iInvoices"><a href="{{ 'invoice'|alink({'status' : 'unpaid'}) }}" title=""><span><i class="sprite-23 sprite-23-money"></i>{% trans 'Invoices' %}</span></a>{% if count_invoices %}<span class="numberMiddle">{{ count_invoices }}</span>{% endif %}</li>
-            {% endif %}
-            
-            {% if admin.system_is_allowed({"mod":"support"}) %}
-            {% set count_tickets = admin.support_ticket_get_statuses.open %}
-            {% set count_ptickets = admin.support_public_ticket_get_statuses.open %}
-        	<li class="iSpeech"><a href="{{ 'support/public-tickets'|alink({'status' : 'open'}) }}" title=""><span><i class="sprite-23 sprite-23-speech"></i>{% trans 'Inquiries' %}</span></a>{% if count_ptickets %}<span class="numberMiddle">{{ count_ptickets }}</span>{% endif %}</li>
-        	<li class="iMes"><a href="{{ 'support'|alink({'status' : 'open'}) }}" title=""><span><i class="sprite-23 sprite-23-dialog"></i>{% trans 'Tickets' %}</span></a>{% if count_tickets %}<span class="numberMiddle">{{ count_tickets }}</span>{% endif %}</li>
-            {% endif %}
-            
-            {% if admin.system_is_allowed({"mod":"client"}) %}
-            <li><a href="{{ 'client'|alink }}" title=""><span><i class="sprite-23 sprite-23-user"></i>{% trans 'Clients' %}</span></a></li>
-            {% endif %}
-            
-        	<li><a href="{{ 'index'|alink }}" title=""><span><i class="sprite-23 sprite-23-home"></i>{% trans 'Dashboard' %}</span></a></li>
-        </ul>
-    </div>
-    <div class="fix"></div>
-</div>
-
-
-<div class="wrapper">
+    <div class="logo"><a href="{{ 'index'|alink }}" title=""><img src="{{ company.logo_url }}" alt="{{ company.name }}" style="max-height: 50px;"/></a></div>
+    
+    <div id="mySidebar" class="sidebar">
+      <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">×</a>
     
     {% if hide_menu %}
     
     {% block content_wide %}{% endblock %}
     
     {% else %}
-    <div class="leftNav">
+    <li><a href="{{ 'index'|alink }}" title=""><span><i class="dark-sprite-icon sprite-home"></i>{% trans 'Dashboard' %}</span></a></li>
     {% block left_top %}{% endblock %}    
     {% block nav %}{% include "partial_menu.phtml" %}{% endblock %}
     {% block left_bottom %}{% endblock %}
     </div>
+    
+    <div class="fix"></div>
+</div>
+
+<div class="wrapper">
     
     {% block before_content %}{% endblock %}
     <div class="content">

--- a/src/bb-themes/admin_default/html/layout_login.phtml
+++ b/src/bb-themes/admin_default/html/layout_login.phtml
@@ -19,11 +19,10 @@
 <div id="topNav">
     <div class="fixed">
         <div class="wrapper">
-            <div class="backTo"><a href="{{ '/'|link }}" title=""><img src="images/icons/topnav/mainWebsite.png" alt="" /><span>{% trans 'Main website' %}</span></a></div>
             <div class="userNav">
                 <ul>
                     <li class="loading" style="display:none;"><img src="images/loader.gif" alt="" /><span>{% trans 'Loading ...' %}</span></li>
-                    <li><a href="http://docs.boxbilling.org/{% if help_query %}en/latest/search.html?q={{help_query}}&check_keywords=yes&area=default{% endif %}" title="" target="_blank"><img src="images/icons/topnav/help.png" alt="" /><span>{% trans 'Help' %}</span></a></li>
+                    <div class="backTo"><a href="{{ '/'|link }}" title=""><img src="images/icons/topnav/mainWebsite.png" alt="" /><span>{% trans 'Main website' %}</span></a></div>
                 </ul>
             </div>
             <div class="fix"></div>

--- a/src/bb-themes/admin_default/html/mod_client_index.phtml
+++ b/src/bb-themes/admin_default/html/mod_client_index.phtml
@@ -134,7 +134,7 @@
                         </td>
                         <td>
                             <span class="flag flag-{{ client.country }}" title="{{ guest.system_countries[client.country] }}"></span>
-                            <a href="{{ 'client/manage'|alink }}/{{ client.id }}" title="{{ client.first_name }} {{ client.last_name }}">{{ client.first_name|truncate('1', null, '.') }} {{ client.last_name|truncate(15) }}</a></td>
+                            <a href="{{ 'client/manage'|alink }}/{{ client.id }}" title="{{ client.first_name }} {{ client.last_name }}">{{ client.first_name|truncate(15) }} {{ client.last_name|truncate('1', null, '.') }}</a></td>
                         <td><a href="{{ 'client/manage'|alink }}/{{ client.id }}" title="{{ client.company }}">{{ client.company|default('-')|truncate(30) }}</a></td>
                         <td><a href="{{ 'client/manage'|alink }}/{{ client.id }}" title="{{ client.email }}">{{ client.email|truncate(30) }}</a></td>
                         <td>{{ mf.status_name(client.status) }}</td>

--- a/src/bb-themes/admin_default/html/mod_index_dashboard.phtml
+++ b/src/bb-themes/admin_default/html/mod_index_dashboard.phtml
@@ -95,7 +95,7 @@
                     {% for order in orders.list %}
                         <tr title="{{order.created_at|timeago}} ago">
                             <td><a href="{{ 'order/manage'|alink }}/{{ order.id }}">{{ order.title|truncate(35) }}</a></td>
-                            <td align="center"><a href="{{ 'client/manage'|alink }}/{{ order.client_id }}" title="">{{ order.client.first_name|truncate(1, null, '.') }} {{ order.client.last_name }}</a></td>
+                            <td align="center"><a href="{{ 'client/manage'|alink }}/{{ order.client_id }}" title="">{{ order.client.first_name|truncate(15) }} {{ order.client.last_name|truncate(1, null, '.') }}</a></td>
                         </tr>
                     {% else %}
                     <tr>

--- a/src/bb-themes/admin_default/html/mod_invoice_index.phtml
+++ b/src/bb-themes/admin_default/html/mod_invoice_index.phtml
@@ -98,9 +98,9 @@
 {% set statuses = admin.invoice_get_statuses %}
 <div class="stats">
     <ul>
-        <li><a href="{{ 'invoice'|alink({'status' : 'unpaid'}) }}" class="count blue" title="">{{ statuses.unpaid }}</a><span>{% trans 'Unpaid invoices' %}</span></li>
-        <li><a href="{{ 'invoice'|alink({'status' : 'refunded'}) }}" class="count red" title="">{{ statuses.refunded }}</a><span>{% trans 'Refunded invoices' %}</span></li>
-        <li><a href="{{ 'invoice'|alink({'status' : 'paid'}) }}" class="count green" title="">{{ statuses.paid }}</a><span>{% trans 'Paid invoices' %}</span></li>
+        <li><a href="{{ 'invoice'|alink({'status' : 'unpaid'}) }}" class="count green" title="">{{ statuses.unpaid }}</a><span>{% trans 'Unpaid invoices' %}</span></li>
+        <li><a href="{{ 'invoice'|alink({'status' : 'refunded'}) }}" class="count blue" title="">{{ statuses.refunded }}</a><span>{% trans 'Refunded invoices' %}</span></li>
+        <li><a href="{{ 'invoice'|alink({'status' : 'paid'}) }}" class="count red" title="">{{ statuses.paid }}</a><span>{% trans 'Paid invoices' %}</span></li>
         <li class="last"><a href="{{ 'invoice'|alink }}" class="count grey" title="">{{ statuses.paid + statuses.unpaid + statuses.refunded}}</a><span>{% trans 'Total' %}</span></li>
     </ul>
     <div class="fix"></div>

--- a/src/bb-themes/admin_default/html/mod_order_index.phtml
+++ b/src/bb-themes/admin_default/html/mod_order_index.phtml
@@ -141,7 +141,7 @@
                             <a href="{{ 'client/manage'|alink }}/{{ order.client_id }}"><img src="{{ order.client.email|gravatar }}?size=20" alt="{{ order.client.email }}" /></a>
                         </span>
                         <span style="margin-left: 10px;">
-                            <a href="{{ 'client/manage'|alink }}/{{ order.client_id }}">{{order.client.first_name|truncate('1', null, '.')}} {{order.client.last_name}}</a>
+                            <a href="{{ 'client/manage'|alink }}/{{ order.client_id }}">{{order.client.first_name|truncate(15)}} {{order.client.last_name|truncate('1', null, '.')}}</a>
                         </span>
                     </td>
                     <td class="truncate">{{order.title }}</td>

--- a/src/bb-themes/admin_default/html/mod_support_public_tickets.phtml
+++ b/src/bb-themes/admin_default/html/mod_support_public_tickets.phtml
@@ -8,7 +8,7 @@
     <ul>
         <li><a href="{{ 'support/public-tickets'|alink({'status' : 'open'}) }}" class="count green" title="">{{ statuses.open }}</a><span>{% trans 'Tickets waiting for staff reply' %}</span></li>
         <li><a href="{{ 'support/public-tickets'|alink({'status' : 'on_hold'}) }}" class="count blue" title="">{{ statuses.on_hold }}</a><span>{% trans 'Tickets waiting for client reply' %}</span></li>
-        <li><a href="{{ 'support/public-tickets'|alink({'status' : 'closed'}) }}" class="count grey" title="">{{ statuses.closed }}</a><span>{% trans 'Solved tickets' %}</span></li>
+        <li><a href="{{ 'support/public-tickets'|alink({'status' : 'closed'}) }}" class="count red" title="">{{ statuses.closed }}</a><span>{% trans 'Solved tickets' %}</span></li>
         <li class="last"><a href="{{ 'support/public-tickets'|alink }}" class="count grey" title="">{{ statuses.open + statuses.on_hold + statuses.closed }}</a><span>{% trans 'Total' %}</span></li>
     </ul>
     <div class="fix"></div>

--- a/src/bb-themes/admin_default/html/mod_support_tickets.phtml
+++ b/src/bb-themes/admin_default/html/mod_support_tickets.phtml
@@ -92,7 +92,7 @@
     <ul>
         <li><a href="{{ 'support'|alink({'status' : 'open'}) }}" class="count green" title="">{{ statuses.open }}</a><span>{% trans 'Tickets waiting for staff reply' %}</span></li>
         <li><a href="{{ 'support'|alink({'status' : 'on_hold'}) }}" class="count blue" title="">{{ statuses.on_hold }}</a><span>{% trans 'Tickets waiting for client reply' %}</span></li>
-        <li><a href="{{ 'support'|alink({'status' : 'closed'}) }}" class="count grey" title="">{{ statuses.closed }}</a><span>{% trans 'Solved tickets' %}</span></li>
+        <li><a href="{{ 'support'|alink({'status' : 'closed'}) }}" class="count red" title="">{{ statuses.closed }}</a><span>{% trans 'Solved tickets' %}</span></li>
         <li class="last"><a href="{{ 'support'|alink }}" class="count grey" title="">{{ statuses.open + statuses.on_hold + statuses.closed }}</a><span>{% trans 'Total' %}</span></li>
     </ul>
     <div class="fix"></div>


### PR DESCRIPTION
Admin theme re-design.

Login page:
-removed top help link as it already could be found in the bottom one.
-moved go to main site link to the right.
-edited css to simplify the mess with positioning.
-made a new login button , with a little animation when clicked.
-added the themed blue line.

Admin panel:
-left menu is now hidden for a cleaner look.
-added dashboard link to the menu.
-top settings link is now settings only, and does not include theme settings anymore.
-removed the top navigation buttons for a cleaner look.
-added order/invoice/support buttons to the top menu with notifications.
-moved profile avatar to the right of the top menu.
-clicking profile name will also redirect to profile page now.
-edited display name for client in certain tables to show entire first name up to 15 characters, and then last name initial only. When a client register, it is asked for his first name only, therefore most of the clients will not update in profile their last name too and this will result into having your statistic tables filled up only with first name initials.
-edited display stats look.
-added the themed blue line.

CSS:
-minified to beautify.

NOTE:
-i haven't touched/checked if is responsive to different resolutions.
-expecting reports if any problem was introduced.
