### PR TITLE
Rebranded 4.22-beta.1-maint to 4.22.1.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -24,7 +24,7 @@ body:
       options:
         - v4.21
         - v4.22-beta.1
-        - v4.22-beta.1-maint
+        - v4.22-beta.1.1
         - Current Master Branch
     validations:
       required: true


### PR DESCRIPTION
We don't need to add extra words, and now we can update incrementally very easily
I think internally, BoxBilling versioning shouldn't even have the word "beta"
We can put it in the name of a release, but keep it out of the tag & version number. But that's important for a different day