### PR TITLE
Be more descriptive with extraction failures

### DIFF
--- a/src/bb-library/Box/Zip.php
+++ b/src/bb-library/Box/Zip.php
@@ -35,7 +35,7 @@ class Box_Zip
         }
         catch(\PhpZip\Exception\ZipException $e){
             $zip->close();
-            throw new \Box_Exception('Failed to extract file!', array(':file'=>$this->zip));
+            throw new \Box_Exception('Failed to extract file! Exception:'. '<br>' . $e);
         }
     }
 }

--- a/src/bb-library/Box/Zip.php
+++ b/src/bb-library/Box/Zip.php
@@ -35,7 +35,7 @@ class Box_Zip
         }
         catch(\PhpZip\Exception\ZipException $e){
             $zip->close();
-            throw new \Box_Exception('Failed to extract file! Exception:'. '<br>' . $e);
+            throw new \Box_Exception('Failed to extract file! Exception:<br>' . $e);
         }
     }
 }


### PR DESCRIPTION
Good idea for debugging failed updating as we once again support that in the latest release.
Otherwise, it'll fail and give no info.

Optionally, we could log the exception and then display the original error