### PR TITLE
Generate downloadable artifact with each commit

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -70,7 +70,7 @@ jobs:
         working-directory: ./build/source/bb-library/Box
 
       - name: Create the final archive
-        run: tar cvf ./build/distribution/BoxBilling-${GITHUB_SHA::7}.tar ./build/source
+        run: tar cvf ./build/distribution/BoxBilling-${GITHUB_SHA::7}.tar -C ./build/source .
 
       - name: Upload the final artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -78,3 +78,4 @@ jobs:
         with:
           name: BoxBilling-${GITHUB_SHA::7}
           path: ./build/distribution/
+          if-no-files-found: error

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -1,0 +1,80 @@
+name: Create a downloadable preview build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.operating-system }}
+      strategy:
+        matrix:
+          operating-system: [ubuntu-latest]
+          php-versions: ['7.4']
+
+    name: Create a downloadable preview build
+     steps:
+      - name: Checkout
+      uses: actions/checkout@v2
+      
+      - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+      
+      - name: Install Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+
+      - name: Check PHP Version
+      run: php -v
+      
+      - name: Validate composer.json and composer.lock
+      run: composer validate
+      working-directory: ./src
+      
+      - name: Install Grunt-CLI
+      run: npm install -g grunt-cli
+      
+      - name: Installing NPM dependencies
+      run: npm install
+      
+      - name: Create temporary directories and files
+      run: |
+        mkdir -p ./src/bb-data/{cache,log,uploads}
+        touch ./src/bb-data/{cache,log,uploads}/index.html
+        mkdir -p ./build/{code-browser,code-coverage,logs,pdepend,update,distribution,source}
+      
+      - name: Copy mandatory files to the temporary build folder
+      run: | 
+        cp ./src/* ./build/source/
+        cp README.md ./build/source/
+        cp LICENSE ./build/source/
+        cp CHANGELOG.md ./build/source/
+        
+      - name: Running Grunt
+      run: grunt
+      working-directory: ./build/source
+      
+      - name: Installing Composer dependencies
+      run: composer install --prefer-dist --no-progress --no-suggest --no-dev --optimize-autoloader
+      working-directory: ./build/source
+      
+      - name: Add short commit hash as the release number
+      run: |
+        sed s/0.0.1/${GITHUB_SHA::6}/ Version.php > Version2.php
+        mv Version2.php Version.php
+      working-directory: ./build/source/bb-library/Box
+      
+      - name: Create the final archive
+      run: zip –r BoxBilling-${GITHUB_SHA::6}.zip ../source
+      working-directory: ./build/distribution
+      
+      - name: Upload the final artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: BoxBilling-${GITHUB_SHA::6}
+        path: ./build/distribution/BoxBilling-${GITHUB_SHA::6}.zip

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -70,8 +70,7 @@ jobs:
         working-directory: ./build/source/bb-library/Box
 
       - name: Create the final archive
-        run: zip -v –r BoxBilling-${GITHUB_SHA::7}.zip ../source/*
-        working-directory: ./build/distribution
+        run: tar cvf ./build/distribution/BoxBilling-${GITHUB_SHA::7}.tar ./build/source
 
       - name: Upload the final artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -76,6 +76,6 @@ jobs:
       - name: Upload the final artifact
         uses: actions/upload-artifact@v2
         with:
-          name: BoxBilling-${GITHUB_SHA::7}
+          name: BoxBilling Preview Archive
           path: ./build/distribution/
           if-no-files-found: error

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -77,4 +77,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: BoxBilling-${GITHUB_SHA::7}
-          path: ./build/distribution/BoxBilling-${GITHUB_SHA::7}.zip
+          path: ./build/distribution/

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Copy mandatory files to the temporary build folder
         run: |
-          cp ./src/* ./build/source/
+          cp -r ./src/* ./build/source/
           cp README.md ./build/source/
           cp LICENSE ./build/source/
           cp CHANGELOG.md ./build/source/

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -70,7 +70,7 @@ jobs:
         working-directory: ./build/source/bb-library/Box
 
       - name: Create the final archive
-        run: zip –r BoxBilling-${GITHUB_SHA::7}.zip ../source
+        run: zip -v –r BoxBilling-${GITHUB_SHA::7}.zip ../source/*
         working-directory: ./build/distribution
 
       - name: Upload the final artifact

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -2,9 +2,9 @@ name: Create a downloadable preview build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
@@ -12,67 +12,67 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4']
+        php-versions: ["7.4"]
 
     name: Create a downloadable preview build
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      
+
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-      
+
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: "16"
 
       - name: Check PHP Version
         run: php -v
-      
+
       - name: Validate composer.json and composer.lock
         run: composer validate
         working-directory: ./src
-      
+
       - name: Install Grunt-CLI
         run: npm install -g grunt-cli
-      
+
       - name: Installing NPM dependencies
         run: npm install
-      
+
       - name: Create temporary directories and files
         run: |
           mkdir -p ./src/bb-data/{cache,log,uploads}
           touch ./src/bb-data/{cache,log,uploads}/index.html
           mkdir -p ./build/{code-browser,code-coverage,logs,pdepend,update,distribution,source}
-      
+
       - name: Copy mandatory files to the temporary build folder
-        run: | 
+        run: |
           cp ./src/* ./build/source/
           cp README.md ./build/source/
           cp LICENSE ./build/source/
           cp CHANGELOG.md ./build/source/
-        
+
       - name: Running Grunt
         run: grunt
         working-directory: ./build/source
-      
+
       - name: Installing Composer dependencies
         run: composer install --prefer-dist --no-progress --no-suggest --no-dev --optimize-autoloader
         working-directory: ./build/source
-      
+
       - name: Add short commit hash as the release number
         run: |
           sed s/0.0.1/${GITHUB_SHA::7}/ Version.php > Version2.php
           mv Version2.php Version.php
         working-directory: ./build/source/bb-library/Box
-      
+
       - name: Create the final archive
         run: zip –r BoxBilling-${GITHUB_SHA::7}.zip ../source
         working-directory: ./build/distribution
-      
+
       - name: Upload the final artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -9,72 +9,72 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.operating-system }}
-      strategy:
-        matrix:
-          operating-system: [ubuntu-latest]
-          php-versions: ['7.4']
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.4']
 
     name: Create a downloadable preview build
-     steps:
+    steps:
       - name: Checkout
-      uses: actions/checkout@v2
+        uses: actions/checkout@v2
       
       - name: Install PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
       
       - name: Install Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: '16'
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
 
       - name: Check PHP Version
-      run: php -v
+        run: php -v
       
       - name: Validate composer.json and composer.lock
-      run: composer validate
-      working-directory: ./src
+        run: composer validate
+        working-directory: ./src
       
       - name: Install Grunt-CLI
-      run: npm install -g grunt-cli
+        run: npm install -g grunt-cli
       
       - name: Installing NPM dependencies
-      run: npm install
+        run: npm install
       
       - name: Create temporary directories and files
-      run: |
-        mkdir -p ./src/bb-data/{cache,log,uploads}
-        touch ./src/bb-data/{cache,log,uploads}/index.html
-        mkdir -p ./build/{code-browser,code-coverage,logs,pdepend,update,distribution,source}
+        run: |
+          mkdir -p ./src/bb-data/{cache,log,uploads}
+          touch ./src/bb-data/{cache,log,uploads}/index.html
+          mkdir -p ./build/{code-browser,code-coverage,logs,pdepend,update,distribution,source}
       
       - name: Copy mandatory files to the temporary build folder
-      run: | 
-        cp ./src/* ./build/source/
-        cp README.md ./build/source/
-        cp LICENSE ./build/source/
-        cp CHANGELOG.md ./build/source/
+        run: | 
+          cp ./src/* ./build/source/
+          cp README.md ./build/source/
+          cp LICENSE ./build/source/
+          cp CHANGELOG.md ./build/source/
         
       - name: Running Grunt
-      run: grunt
-      working-directory: ./build/source
+        run: grunt
+        working-directory: ./build/source
       
       - name: Installing Composer dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest --no-dev --optimize-autoloader
-      working-directory: ./build/source
+        run: composer install --prefer-dist --no-progress --no-suggest --no-dev --optimize-autoloader
+        working-directory: ./build/source
       
       - name: Add short commit hash as the release number
-      run: |
-        sed s/0.0.1/${GITHUB_SHA::6}/ Version.php > Version2.php
-        mv Version2.php Version.php
-      working-directory: ./build/source/bb-library/Box
+        run: |
+          sed s/0.0.1/${GITHUB_SHA::7}/ Version.php > Version2.php
+          mv Version2.php Version.php
+        working-directory: ./build/source/bb-library/Box
       
       - name: Create the final archive
-      run: zip –r BoxBilling-${GITHUB_SHA::6}.zip ../source
-      working-directory: ./build/distribution
+        run: zip –r BoxBilling-${GITHUB_SHA::7}.zip ../source
+        working-directory: ./build/distribution
       
       - name: Upload the final artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: BoxBilling-${GITHUB_SHA::6}
-        path: ./build/distribution/BoxBilling-${GITHUB_SHA::6}.zip
+        uses: actions/upload-artifact@v2
+        with:
+          name: BoxBilling-${GITHUB_SHA::7}
+          path: ./build/distribution/BoxBilling-${GITHUB_SHA::7}.zip


### PR DESCRIPTION
Creates a downloadable artifact that includes Composer dependencies and everything after each commit.
Uses first 7 character of the commit hash as the release number. (e.g. `1bfdbae`)

Closes #1110.