### PR TITLE
Drop PHP 7.4 from GitHub workflows

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest]
 
-        php-versions: ["7.4"]
+        php-versions: ["8.0"]
 
 
     name: Create a downloadable preview build

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ["7.4", "8.0", "8.1"]
+        php-versions: ["8.0", "8.1"]
 
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:


### PR DESCRIPTION
This PR drops any tests about PHP 7.4 and starts using PHP 8.0 instead for the artifact generator.