### PR TITLE
[Fix] Bug in exception not found

### DIFF
--- a/src/bb-load.php
+++ b/src/bb-load.php
@@ -213,10 +213,10 @@ function handler_exception($e)
       print sprintf('<p>%s</p>', $e->getMessage());
       
       print sprintf('<center><p><a href="http://docs.boxbilling.com/en/latest/search.html?q=%s&check_keywords=yes&area=default" target="_blank">Look for detailed error explanation</a></p></center>', urlencode($e->getMessage()));
-      print("<center><hr><p>Powered by <a href=//https://github.com/boxbilling/boxbilling/>BoxBilling</a></p></center>
+      print('<center><hr><p>Powered by <a href="https://github.com/boxbilling/boxbilling/">BoxBilling</a></p></center>
       </body>
       
-      </html>");
+      </html>');
     }
   }
 }


### PR DESCRIPTION
Powered by link leads to //https://github.com instead of https://github.com causing link to not work