### PR TITLE
Display release notes on the update screen

### DIFF
--- a/src/bb-library/Box/Update.php
+++ b/src/bb-library/Box/Update.php
@@ -44,7 +44,20 @@ class Box_Update
     }
 
     /**
-     * Return latest version number
+     * Returns latest release notes
+     * @return string
+     */
+    public function getLatestReleaseNotes()
+    {
+        $response = $this->_getLatestVersionInfo();
+        if(!isset($response['body'])){
+            return "**Error: Release info unavailable**";
+        }
+        return $response['body'];
+    }
+
+    /**
+     * Returns latest version number
      * @return string
      */
     public function getLatestVersion()

--- a/src/bb-modules/System/Api/Admin.php
+++ b/src/bb-modules/System/Api/Admin.php
@@ -162,4 +162,15 @@ class Admin extends \Api_Abstract
     {
         return $this->getService()->clearCache();
     }
+    
+    /**
+     * Gets the latest release notes.
+     *
+     * @return string
+     */
+    public function release_notes()
+    {
+        $updater = $this->di['updater'];
+        return $updater->getLatestReleaseNotes();
+    }
 }

--- a/src/bb-themes/admin_default/html/mod_extension_index.phtml
+++ b/src/bb-themes/admin_default/html/mod_extension_index.phtml
@@ -108,6 +108,7 @@
             </div>
 
             <div class="body">
+                {{ admin.system_release_notes|bbmd }}
                 <a href="{{ 'api/admin/extension/update_core'|link }}" title="" class="btnIconLeft mr10 mt5 api-link" data-api-confirm="Make sure that you have made database and files backups before proceeding with automatic update. Click OK when you are ready to continue." data-api-msg="Update complete"><img src="images/icons/dark/cog.png" alt="" class="icon"><span>Update BoxBilling</span></a>
             </div>
 

--- a/src/bb-themes/admin_default/html/mod_extension_index.phtml
+++ b/src/bb-themes/admin_default/html/mod_extension_index.phtml
@@ -119,10 +119,10 @@
 
             <div class="body list arrowGreen">
                 <ul>
-                    <li>Download latest BoxBilling from <a href="https://github.com/boxbilling/boxbilling/releases" target="_blank">Our Github</a></li>
-                    <li>Extract files at your computer</li>
+                    <li>Download the latest release from <a href="https://github.com/boxbilling/boxbilling/releases" target="_blank">GitHub</a></li>
+                    <li>Extract the files into your computer</li>
                     <li>Upload (overwrite) extracted files via FTP to <strong>{{ constant('BB_PATH_ROOT') }}</strong></li>
-                    <li>When upload is complete, execute <a href="{{constant('BB_URL')}}bb-update.php" target="_blank">{{constant('BB_URL')}}bb-update.php</a> in your browser</li>
+                    <li>When the uploading is done, execute <a href="{{constant('BB_URL')}}bb-update.php" target="_blank">{{constant('BB_URL')}}bb-update.php</a> in your browser</li>
                     <li>Your BoxBilling is now updated to latest version.</li>
                 </ul>
             </div>


### PR DESCRIPTION
Now if we introduce some kind of breaking or significant change, people will see it on the release page.
Figured we can push one more release that supports PHP 7.4 & let this addition roll out so people will get some kind of warning before updating. Hopefully will avoid extra support tickets.

![image](https://user-images.githubusercontent.com/17304943/161442089-11e73342-28be-40e6-b3da-0f4eab4916d0.png)
