### PR TITLE
fix bug: admin theme not change

### DIFF
--- a/src/bb-modules/Theme/Service.php
+++ b/src/bb-modules/Theme/Service.php
@@ -247,7 +247,7 @@ class Service implements InjectionAwareInterface
                ';
         $default = 'admin_default';
         $theme = $this->di['db']->getCell($query, ['param' => 'admin_theme']);
-        $path = BB_PATH_THEMES.DIRECTORY_SEPARATOR.$theme;
+        $path = BB_PATH_THEMES.DIRECTORY_SEPARATOR;
         if (null == $theme || !file_exists($path.$theme)) {
             $theme = $default;
         }


### PR DESCRIPTION
Bug details:

Let's assume I have two admin themes,
- admin_default
- admin_nawafinity

When I change the theme to `admin_nawafinity` in the settings the BillingBox keeps shows the default theme.
